### PR TITLE
Add type hints and reformat with Python black

### DIFF
--- a/models/module.py
+++ b/models/module.py
@@ -1,73 +1,169 @@
+"""
+Implementation of Pytorch layer primitives, such as Conv+BN+ReLU, differentiable warping layers,
+and depth regression based upon expectation of an input probability distribution.
+"""
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
 
-
 class ConvBnReLU(nn.Module):
-    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, pad=1, dilation=1):
-        super(ConvBnReLU, self).__init__()
-        self.conv = nn.Conv2d(in_channels, out_channels, kernel_size, stride=stride, padding=pad, dilation=dilation, bias=False)
-        self.bn = nn.BatchNorm2d(out_channels)
-        
+    """Implements 2d Convolution + batch normalization + ReLU"""
 
-    def forward(self,x):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 3,
+        stride: int = 1,
+        pad: int = 1,
+        dilation: int = 1,
+    ) -> None:
+        """initialization method for convolution2D + batch normalization + relu module
+        Args:
+            in_channels: input channel number of convolution layer
+            out_channels: output channel number of convolution layer
+            kernel_size: kernel size of convolution layer
+            stride: stride of convolution layer
+            pad: pad of convolution layer
+            dilation: dilation of convolution layer
+        """
+        super(ConvBnReLU, self).__init__()
+        self.conv = nn.Conv2d(
+            in_channels, out_channels, kernel_size, stride=stride, padding=pad, dilation=dilation, bias=False
+        )
+        self.bn = nn.BatchNorm2d(out_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """forward method"""
         return F.relu(self.bn(self.conv(x)), inplace=True)
+
 
 class ConvBnReLU3D(nn.Module):
-    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, pad=1, dilation=1):
+    """Implements of 3d convolution + batch normalization + ReLU."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 3,
+        stride: int = 1,
+        pad: int = 1,
+        dilation: int = 1,
+    ) -> None:
+        """initialization method for convolution3D + batch normalization + relu module
+        Args:
+            in_channels: input channel number of convolution layer
+            out_channels: output channel number of convolution layer
+            kernel_size: kernel size of convolution layer
+            stride: stride of convolution layer
+            pad: pad of convolution layer
+            dilation: dilation of convolution layer
+        """
         super(ConvBnReLU3D, self).__init__()
-        self.conv = nn.Conv3d(in_channels, out_channels, kernel_size, stride=stride, padding=pad, dilation=dilation, bias=False)
+        self.conv = nn.Conv3d(
+            in_channels, out_channels, kernel_size, stride=stride, padding=pad, dilation=dilation, bias=False
+        )
         self.bn = nn.BatchNorm3d(out_channels)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """forward method"""
         return F.relu(self.bn(self.conv(x)), inplace=True)
+
 
 class ConvBnReLU1D(nn.Module):
-    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, pad=1, dilation=1):
+    """Implements 1d Convolution + batch normalization + ReLU."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int = 3,
+        stride: int = 1,
+        pad: int = 1,
+        dilation: int = 1,
+    ) -> None:
+        """initialization method for convolution1D + batch normalization + relu module
+        Args:
+            in_channels: input channel number of convolution layer
+            out_channels: output channel number of convolution layer
+            kernel_size: kernel size of convolution layer
+            stride: stride of convolution layer
+            pad: pad of convolution layer
+            dilation: dilation of convolution layer
+        """
         super(ConvBnReLU1D, self).__init__()
-        self.conv = nn.Conv1d(in_channels, out_channels, kernel_size, stride=stride, padding=pad, dilation=dilation, bias=False)
+        self.conv = nn.Conv1d(
+            in_channels, out_channels, kernel_size, stride=stride, padding=pad, dilation=dilation, bias=False
+        )
         self.bn = nn.BatchNorm1d(out_channels)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """forward method"""
         return F.relu(self.bn(self.conv(x)), inplace=True)
-        
+
 
 class ConvBn(nn.Module):
-    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, pad=1):
+    """Implements of 2d convolution + batch normalization."""
+
+    def __init__(
+        self, in_channels: int, out_channels: int, kernel_size: int = 3, stride: int = 1, pad: int = 1
+    ) -> None:
+        """initialization method for convolution2D + batch normalization + ReLU module
+        Args:
+            in_channels: input channel number of convolution layer
+            out_channels: output channel number of convolution layer
+            kernel_size: kernel size of convolution layer
+            stride: stride of convolution layer
+            pad: pad of convolution layer
+        """
         super(ConvBn, self).__init__()
         self.conv = nn.Conv2d(in_channels, out_channels, kernel_size, stride=stride, padding=pad, bias=False)
         self.bn = nn.BatchNorm2d(out_channels)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """forward method"""
         return self.bn(self.conv(x))
 
 
+def differentiable_warping(
+    src_fea: torch.Tensor, src_proj: torch.Tensor, ref_proj: torch.Tensor, depth_samples: torch.Tensor
+):
+    """Differentiable homography-based warping, implemented in Pytorch.
 
-def differentiable_warping(src_fea, src_proj, ref_proj, depth_samples):
-    # src_fea: [B, C, H, W]
-    # src_proj: [B, 4, 4]
-    # ref_proj: [B, 4, 4]
-    # depth_samples: [B, Ndepth, H, W] 
-    # out: [B, C, Ndepth, H, W]
+    Args:
+        src_fea: [B, C, H, W] source features, for each source view in batch
+        src_proj: [B, 4, 4] source camera poses, for each source view in batch
+        ref_proj: [B, 4, 4] reference camera pose, for each ref view in batch
+        depth_samples: [B, Ndepth, H, W] virtual depth layers
+    Returns:
+        warped_src_fea: [B, C, Ndepth, H, W] features on depths after perspective transformation
+    """
+
     batch, channels, height, width = src_fea.shape
     num_depth = depth_samples.shape[1]
-    
+
     with torch.no_grad():
         proj = torch.matmul(src_proj, torch.inverse(ref_proj))
         rot = proj[:, :3, :3]  # [B,3,3]
         trans = proj[:, :3, 3:4]  # [B,3,1]
 
-        y, x = torch.meshgrid([torch.arange(0, height, dtype=torch.float32, device=src_fea.device),
-                            torch.arange(0, width, dtype=torch.float32, device=src_fea.device)])
+        y, x = torch.meshgrid(
+            [
+                torch.arange(0, height, dtype=torch.float32, device=src_fea.device),
+                torch.arange(0, width, dtype=torch.float32, device=src_fea.device),
+            ]
+        )
         y, x = y.contiguous(), x.contiguous()
         y, x = y.view(height * width), x.view(height * width)
         xyz = torch.stack((x, y, torch.ones_like(x)))  # [3, H*W]
         xyz = torch.unsqueeze(xyz, 0).repeat(batch, 1, 1)  # [B, 3, H*W]
         rot_xyz = torch.matmul(rot, xyz)  # [B, 3, H*W]
 
-        rot_depth_xyz = rot_xyz.unsqueeze(2).repeat(1, 1, num_depth, 1) * depth_samples.view(batch, 1, num_depth,
-                                                                                            height * width)  # [B, 3, Ndepth, H*W]
+        rot_depth_xyz = rot_xyz.unsqueeze(2).repeat(1, 1, num_depth, 1) * depth_samples.view(
+            batch, 1, num_depth, height * width
+        )  # [B, 3, Ndepth, H*W]
         proj_xyz = rot_depth_xyz + trans.view(batch, 3, 1, 1)  # [B, 3, Ndepth, H*W]
         # avoid negative depth
         negative_depth_mask = proj_xyz[:, 2:] <= 1e-3
@@ -75,29 +171,51 @@ def differentiable_warping(src_fea, src_proj, ref_proj, depth_samples):
         proj_xyz[:, 1:2][negative_depth_mask] = height
         proj_xyz[:, 2:3][negative_depth_mask] = 1
         proj_xy = proj_xyz[:, :2, :, :] / proj_xyz[:, 2:3, :, :]  # [B, 2, Ndepth, H*W]
-        proj_x_normalized = proj_xy[:, 0, :, :] / ((width - 1) / 2) - 1 # [B, Ndepth, H*W]
+        proj_x_normalized = proj_xy[:, 0, :, :] / ((width - 1) / 2) - 1  # [B, Ndepth, H*W]
         proj_y_normalized = proj_xy[:, 1, :, :] / ((height - 1) / 2) - 1
         proj_xy = torch.stack((proj_x_normalized, proj_y_normalized), dim=3)  # [B, Ndepth, H*W, 2]
-        grid = proj_xy      
+        grid = proj_xy
 
-    warped_src_fea = F.grid_sample(src_fea, grid.view(batch, num_depth * height, width, 2), mode='bilinear',
-                                padding_mode='zeros',align_corners=True)
-    
+    warped_src_fea = F.grid_sample(
+        src_fea,
+        grid.view(batch, num_depth * height, width, 2),
+        mode="bilinear",
+        padding_mode="zeros",
+        align_corners=True,
+    )
+
     warped_src_fea = warped_src_fea.view(batch, channels, num_depth, height, width)
 
     return warped_src_fea
 
-# p: probability volume [B, D, H, W]
-# depth_values: discrete depth values [B, D]
-# get expected value, soft argmin
-# return: depth [B, 1, H, W]
-def depth_regression(p, depth_values):
+
+def depth_regression(p: torch.Tensor, depth_values: torch.Tensor) -> torch.Tensor:
+    """Implements per-pixel depth regression based upon a probability distribution per-pixel.
+
+    The regressed depth value D(p) at pixel p is found as the expectation w.r.t. P of the hypotheses.
+
+    Args:
+        p: probability volume [B, D, H, W]
+        depth_values: discrete depth values [B, D]
+    Returns:
+        result depth: expected value, soft argmin [B, 1, H, W]
+    """
+
     depth_values = depth_values.view(*depth_values.shape, 1, 1)
-    depth = torch.sum(p * depth_values, 1)
+    depth = torch.sum(p * depth_values, dim=1)
     depth = depth.unsqueeze(1)
     return depth
 
-def depth_regression_1(p, depth_values):
+
+def depth_regression_1(p: torch.Tensor, depth_values: torch.Tensor) -> torch.Tensor:
+    """another version of depth regression function
+    Args:
+        p: probability volume [B, D, H, W]
+        depth_values: discrete depth values [B, D]
+    Returns:
+        result depth: expected value, soft argmin [B, 1, H, W]
+    """
+
     depth = torch.sum(p * depth_values, 1)
     depth = depth.unsqueeze(1)
     return depth


### PR DESCRIPTION
Hi @FangjinhuaWang, thanks for sharing your great work and congrats on your CVPR oral. I've added a few changes to the `module.py` file:

1. Added type hints for clarity
2. Reformatted with [Python black](https://github.com/psf/black) for improved readability
3. Added docstrings per the [Google Python style guide](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods)

Is this something you would consider pulling into your repo?