### PR TITLE
Required changes to allow TorchScript export of PatchMatchNet module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
 venv
-__pycache__
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+venv
+__pycache__

--- a/eval_custom.py
+++ b/eval_custom.py
@@ -132,24 +132,24 @@ def save_depth():
     # load checkpoint file specified by args.loadckpt
     print("loading model {}".format(args.loadckpt))
     state_dict = torch.load(args.loadckpt)
-    model.load_state_dict(state_dict['model'])
+    model.load_state_dict(state_dict['model'], strict=False)
     model.eval()
     
     with torch.no_grad():
         for batch_idx, sample in enumerate(TestImgLoader):
             start_time = time.time()
             sample_cuda = tocuda(sample)
-            outputs = model(sample_cuda["imgs"], sample_cuda["proj_matrices"], sample_cuda["depth_min"], sample_cuda["depth_max"])
-            
-            outputs = tensor2numpy(outputs)
+            refined_depth, confidence, _ = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
+                                                 sample_cuda["depth_min"], sample_cuda["depth_max"])
+            refined_depth = tensor2numpy(refined_depth)
+            confidence = tensor2numpy(confidence)
+
             del sample_cuda
             print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(TestImgLoader), time.time() - start_time))
             filenames = sample["filename"]
 
-            
             # save depth maps and confidence maps
-            for filename, depth_est, photometric_confidence in zip(filenames, outputs["refined_depth"]['stage_0'],
-                                                                outputs["photometric_confidence"]):
+            for filename, depth_est, photometric_confidence in zip(filenames, refined_depth, confidence):
                 depth_filename = os.path.join(args.outdir, filename.format('depth_est', '.pfm'))
                 confidence_filename = os.path.join(args.outdir, filename.format('confidence', '.pfm'))
                 os.makedirs(depth_filename.rsplit('/', 1)[0], exist_ok=True)

--- a/eval_eth.py
+++ b/eval_eth.py
@@ -132,24 +132,24 @@ def save_depth():
     # load checkpoint file specified by args.loadckpt
     print("loading model {}".format(args.loadckpt))
     state_dict = torch.load(args.loadckpt)
-    model.load_state_dict(state_dict['model'])
+    model.load_state_dict(state_dict['model'], strict=False)
     model.eval()
     
     with torch.no_grad():
         for batch_idx, sample in enumerate(TestImgLoader):
             start_time = time.time()
             sample_cuda = tocuda(sample)
-            outputs = model(sample_cuda["imgs"], sample_cuda["proj_matrices"], sample_cuda["depth_min"], sample_cuda["depth_max"])
-            
-            outputs = tensor2numpy(outputs)
+            refined_depth, confidence, _ = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
+                                                 sample_cuda["depth_min"], sample_cuda["depth_max"])
+            refined_depth = tensor2numpy(refined_depth)
+            confidence = tensor2numpy(confidence)
+
             del sample_cuda
             print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(TestImgLoader), time.time() - start_time))
             filenames = sample["filename"]
 
-            
             # save depth maps and confidence maps
-            for filename, depth_est, photometric_confidence in zip(filenames, outputs["refined_depth"]['stage_0'],
-                                                                outputs["photometric_confidence"]):
+            for filename, depth_est, photometric_confidence in zip(filenames, refined_depth, confidence):
                 depth_filename = os.path.join(args.outdir, filename.format('depth_est', '.pfm'))
                 confidence_filename = os.path.join(args.outdir, filename.format('confidence', '.pfm'))
                 os.makedirs(depth_filename.rsplit('/', 1)[0], exist_ok=True)

--- a/eval_tank.py
+++ b/eval_tank.py
@@ -125,23 +125,24 @@ def save_depth():
 
     print("loading model {}".format(args.loadckpt))
     state_dict = torch.load(args.loadckpt)
-    model.load_state_dict(state_dict['model'])
+    model.load_state_dict(state_dict['model'], strict=False)
     model.eval()
     
     with torch.no_grad():
         for batch_idx, sample in enumerate(TestImgLoader):
             start_time = time.time()
             sample_cuda = tocuda(sample)
-            outputs = model(sample_cuda["imgs"], sample_cuda["proj_matrices"], sample_cuda["depth_min"], sample_cuda["depth_max"])
+            refined_depth, confidence, _ = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
+                                                 sample_cuda["depth_min"], sample_cuda["depth_max"])
+            refined_depth = tensor2numpy(refined_depth)
+            confidence = tensor2numpy(confidence)
 
-            outputs = tensor2numpy(outputs)
             del sample_cuda
             print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(TestImgLoader), time.time() - start_time))
             filenames = sample["filename"]
 
             # save depth maps and confidence maps
-            for filename, depth_est, photometric_confidence in zip(filenames, outputs["refined_depth"]['stage_0'],
-                                                                outputs["photometric_confidence"]):
+            for filename, depth_est, photometric_confidence in zip(filenames, refined_depth, confidence):
                 depth_filename = os.path.join(args.outdir, filename.format('depth_est', '.pfm'))
                 confidence_filename = os.path.join(args.outdir, filename.format('confidence', '.pfm'))
                 os.makedirs(depth_filename.rsplit('/', 1)[0], exist_ok=True)

--- a/models/module.py
+++ b/models/module.py
@@ -201,7 +201,7 @@ def depth_regression(p: torch.Tensor, depth_values: torch.Tensor) -> torch.Tenso
         result depth: expected value, soft argmin [B, 1, H, W]
     """
 
-    depth_values = depth_values.view(*depth_values.shape, 1, 1)
+    depth_values = depth_values.view(depth_values.shape[0], 1, 1)
     depth = torch.sum(p * depth_values, dim=1)
     depth = depth.unsqueeze(1)
     return depth

--- a/models/patchmatch.py
+++ b/models/patchmatch.py
@@ -238,8 +238,7 @@ class Evaluation(nn.Module):
             ), "Patchmatch Evaluation: Different number of images and view weights"
 
         # Change to a tensor with value 1e-5
-        pixel_wise_weight_sum = 1e-5
-        # pixel_wise_weight_sum = torch.zeros((batch, 1, 1, height, width), dtype=torch.float32, device=device)
+        pixel_wise_weight_sum = 1e-5 * torch.ones((batch, 1, 1, height, width), dtype=torch.float32, device=device)
         ref_feature = ref_feature.view(batch, self.G, feature_channel // self.G, height, width)
         similarity_sum = torch.zeros((batch, self.G, num_depth, height, width), dtype=torch.float32, device=device)
 

--- a/models/patchmatch.py
+++ b/models/patchmatch.py
@@ -5,7 +5,7 @@ PatchmatchNet uses the following main steps:
 2. Propagation: propagate hypotheses to neighbors;
 3. Evaluation: compute the matching costs for all the hypotheses and choose best solutions.
 """
-from typing import List, Optional, Tuple, Union
+from typing import List, Tuple
 
 import torch
 import torch.nn as nn
@@ -35,7 +35,7 @@ class DepthInitialization(nn.Module):
         width: int,
         depth_interval_scale: float,
         device: torch.device,
-        depth: torch.Tensor = None,
+        depth: torch.Tensor = torch.empty(0),
     ) -> torch.Tensor:
         """Forward function for depth initialization
 
@@ -100,8 +100,6 @@ class DepthInitialization(nn.Module):
                     )
 
                 depth_sample = 1.0 / torch.cat(depth_clamped, dim=0)
-                del depth_clamped
-
                 return depth_sample
 
 
@@ -183,9 +181,8 @@ class Evaluation(nn.Module):
 
         self.G = G
         self.stage = stage
-        if self.stage == 3:
-            self.pixel_wise_net = PixelwiseNet(self.G)
-
+        self.pixel_wise_net = PixelwiseNet(self.G)
+        self.softmax = nn.LogSoftmax(dim=1)
         self.similarity_net = SimilarityNet(self.G, evaluate_neighbors)
 
     def forward(
@@ -198,10 +195,10 @@ class Evaluation(nn.Module):
         depth_min: torch.Tensor,
         depth_max: torch.Tensor,
         iter: int,
-        grid: torch.Tensor = None,
-        weight: torch.Tensor = None,
-        view_weights: torch.Tensor = None,
-    ) -> Union[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+        grid: torch.Tensor,
+        weight: torch.Tensor,
+        view_weights: torch.Tensor = torch.empty(0),
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Forward method for adaptive evaluation
 
         Args:
@@ -235,18 +232,18 @@ class Evaluation(nn.Module):
         assert (
             num_src_features == num_src_projs
         ), "Patchmatch Evaluation: Different number of images and projection matrices"
-        if view_weights is not None:
+        if view_weights.numel() > 0:
             assert (
                 num_src_features == view_weights.size()[1]
             ), "Patchmatch Evaluation: Different number of images and view weights"
 
+        # Change to a tensor with value 1e-5
         pixel_wise_weight_sum = 1e-5
-
+        # pixel_wise_weight_sum = torch.zeros((batch, 1, 1, height, width), dtype=torch.float32, device=device)
         ref_feature = ref_feature.view(batch, self.G, feature_channel // self.G, height, width)
+        similarity_sum = torch.zeros((batch, self.G, num_depth, height, width), dtype=torch.float32, device=device)
 
-        similarity_sum = 0
-
-        if self.stage == 3 and view_weights is None:
+        if self.stage == 3 and view_weights.numel() == 0:
             view_weights_list = []
             for src_feature, src_proj in zip(src_features, src_projs):
 
@@ -265,19 +262,17 @@ class Evaluation(nn.Module):
                     similarity_sum += similarity * view_weight.unsqueeze(1)
                     pixel_wise_weight_sum += view_weight.unsqueeze(1)
 
-                del warped_feature, src_feature, src_proj, similarity, view_weight
-            del src_features, src_projs
             view_weights = torch.cat(view_weights_list, dim=1)  # [B,4,H,W], 4 is the number of source views
             # aggregated matching cost across all the source views
             similarity = similarity_sum.div_(pixel_wise_weight_sum)  # [B, G, Ndepth, H, W]
-            del ref_feature, pixel_wise_weight_sum, similarity_sum
+
             # adaptive spatial cost aggregation
             score = self.similarity_net(similarity, grid, weight)  # [B, G, Ndepth, H, W]
-            del similarity, grid, weight
 
             # apply softmax to get probability
-            softmax = nn.LogSoftmax(dim=1)
-            score = softmax(score)
+            # Either way seems to work here
+            score = self.softmax(score)
+            # score = torch.log_softmax(score, dim=1)
             score = torch.exp(score)
 
             # depth regression: expectation
@@ -290,9 +285,9 @@ class Evaluation(nn.Module):
                 warped_feature = differentiable_warping(src_feature, src_proj, ref_proj, depth_sample)
                 warped_feature = warped_feature.view(batch, self.G, feature_channel // self.G, num_depth, height, width)
                 similarity = (warped_feature * ref_feature.unsqueeze(3)).mean(2)
+
                 # reuse the pixel-wise view weight from first iteration of Patchmatch on stage 3
-                if view_weights is not None:
-                    view_weight = view_weights[:, i].unsqueeze(1)  # [B,1,H,W]
+                view_weight = view_weights[:, i].unsqueeze(1)  # [B,1,H,W]
                 i = i + 1
 
                 if self.training:
@@ -302,19 +297,13 @@ class Evaluation(nn.Module):
                     similarity_sum += similarity * view_weight.unsqueeze(1)
                     pixel_wise_weight_sum += view_weight.unsqueeze(1)
 
-                del warped_feature, src_feature, src_proj, similarity, view_weight
-            del src_features, src_projs
-
             # [B, G, Ndepth, H, W]
             similarity = similarity_sum.div_(pixel_wise_weight_sum)
-
-            del ref_feature, pixel_wise_weight_sum, similarity_sum
-
             score = self.similarity_net(similarity, grid, weight)  # [B, Ndepth, H, W]
-            del similarity, grid, weight
 
-            softmax = nn.LogSoftmax(dim=1)
-            score = softmax(score)
+            # Either way seems to work here
+            score = self.softmax(score)
+            # score = torch.log_softmax(score, dim=1)
             score = torch.exp(score)
 
             if self.stage == 1 and iter == self.iterations:
@@ -329,13 +318,13 @@ class Evaluation(nn.Module):
                 )
                 depth_sample = 1.0 / depth_sample
 
-                return depth_sample, score
+                return depth_sample, score, torch.empty(0)
 
             # depth regression: expectation
             else:
                 depth_sample = torch.sum(depth_sample * score, dim=1)
 
-                return depth_sample, score
+                return depth_sample, score, torch.empty(0)
 
 
 class PatchMatch(nn.Module):
@@ -387,20 +376,19 @@ class PatchMatch(nn.Module):
         self.evaluate_neighbors = evaluate_neighbors
         self.evaluation = Evaluation(self.G, self.stage, self.evaluate_neighbors, self.patchmatch_iteration)
         # adaptive propagation
-        if self.propagate_neighbors > 0:
-            # last iteration on stage 1 does not have propagation (photometric consistency filtering)
-            if not (self.stage == 1 and self.patchmatch_iteration == 1):
-                self.propa_conv = nn.Conv2d(
-                    in_channels=self.propa_num_feature,
-                    out_channels=2 * self.propagate_neighbors,
-                    kernel_size=3,
-                    stride=1,
-                    padding=self.dilation,
-                    dilation=self.dilation,
-                    bias=True,
-                )
-                nn.init.constant_(self.propa_conv.weight, 0.0)
-                nn.init.constant_(self.propa_conv.bias, 0.0)
+        # last iteration on stage 1 does not have propagation, but we still define this for TorchScript export compatibility
+        # This may have some impact on training! need to investigate
+        self.propa_conv = nn.Conv2d(
+            in_channels=self.propa_num_feature,
+            out_channels=max(2 * self.propagate_neighbors, 1),
+            kernel_size=3,
+            stride=1,
+            padding=self.dilation,
+            dilation=self.dilation,
+            bias=True,
+        )
+        nn.init.constant_(self.propa_conv.weight, 0.0)
+        nn.init.constant_(self.propa_conv.bias, 0.0)
 
         # adaptive spatial cost aggregation (adaptive evaluation)
         self.eval_conv = nn.Conv2d(
@@ -417,7 +405,7 @@ class PatchMatch(nn.Module):
         self.feature_weight_net = FeatureWeightNet(num_feature, self.evaluate_neighbors, self.G)
 
     def get_propagation_grid(
-        self, batch: int, height: int, width: int, offset: torch.Tensor, device: torch.device, img: torch.Tensor = None
+        self, batch: int, height: int, width: int, offset: torch.Tensor, device: torch.device, img: torch.Tensor
     ) -> torch.Tensor:
         """Compute the offset for adaptive propagation
 
@@ -486,18 +474,21 @@ class PatchMatch(nn.Module):
 
         xy = torch.cat(xy_list, dim=2)  # [B, 2, 9, H*W]
 
-        del xy_list, x_grid, y_grid
+        del xy_list
+        del x_grid
+        del y_grid
 
         x_normalized = xy[:, 0, :, :] / ((width - 1) / 2) - 1
         y_normalized = xy[:, 1, :, :] / ((height - 1) / 2) - 1
         del xy
         grid = torch.stack((x_normalized, y_normalized), dim=3)  # [B, 9, H*W, 2]
-        del x_normalized, y_normalized
+        del x_normalized
+        del y_normalized
         grid = grid.view(batch, self.propagate_neighbors * height, width, 2)
         return grid
 
     def get_evaluation_grid(
-        self, batch: int, height: int, width: int, offset: torch.Tensor, device: torch.device, img: torch.Tensor = None
+        self, batch: int, height: int, width: int, offset: torch.Tensor, device: torch.device, img: torch.Tensor
     ) -> torch.Tensor:
         """Compute the offsets for adaptive spatial cost aggregation in adaptive evaluation
 
@@ -568,12 +559,15 @@ class PatchMatch(nn.Module):
 
         xy = torch.cat(xy_list, dim=2)  # [B, 2, 9, H*W]
 
-        del xy_list, x_grid, y_grid
+        del xy_list
+        del x_grid
+        del y_grid
         x_normalized = xy[:, 0, :, :] / ((width - 1) / 2) - 1
         y_normalized = xy[:, 1, :, :] / ((height - 1) / 2) - 1
         del xy
         grid = torch.stack((x_normalized, y_normalized), dim=3)  # [B, 9, H*W, 2]
-        del x_normalized, y_normalized
+        del x_normalized
+        del y_normalized
         grid = grid.view(batch, len(original_offset) * height, width, 2)
         return grid
 
@@ -585,10 +579,10 @@ class PatchMatch(nn.Module):
         src_projs: List[torch.Tensor],
         depth_min: torch.Tensor,
         depth_max: torch.Tensor,
-        depth: torch.Tensor = None,
-        img: torch.Tensor = None,
-        view_weights: torch.Tensor = None,
-    ) -> Tuple[List[torch.Tensor], torch.Tensor, Optional[torch.Tensor]]:
+        depth: torch.Tensor,
+        img: torch.Tensor,
+        view_weights: torch.Tensor = torch.empty(0),
+    ) -> Tuple[List[torch.Tensor], torch.Tensor, torch.Tensor]:
         """Forward method for PatchMatch
 
         Args:
@@ -608,7 +602,7 @@ class PatchMatch(nn.Module):
         Returns:
             depth_samples: list of depth maps from each patchmatch iteration, Niter * (B,1,H,W)
             score: evaluted probabilities, (B,Ndepth,H,W)
-            view_weights(optional): Tensor to store weights of source views, in shape of (B,Nview-1,H,W),
+            view_weights: Tensor to store weights of source views, in shape of (B,Nview-1,H,W),
                 Nview-1 represents the number of source views
         """
         depth_samples = []
@@ -617,12 +611,12 @@ class PatchMatch(nn.Module):
         batch, _, height, width = ref_feature.size()
 
         # the learned additional 2D offsets for adaptive propagation
-        if self.propagate_neighbors > 0:
+        propa_grid = torch.empty(0)
+        if self.propagate_neighbors > 0 and not (self.stage == 1 and self.patchmatch_iteration == 1):
             # last iteration on stage 1 does not have propagation (photometric consistency filtering)
-            if not (self.stage == 1 and self.patchmatch_iteration == 1):
-                propa_offset = self.propa_conv(ref_feature)
-                propa_offset = propa_offset.view(batch, 2 * self.propagate_neighbors, height * width)
-                propa_grid = self.get_propagation_grid(batch, height, width, propa_offset, device, img)
+            propa_offset = self.propa_conv(ref_feature)
+            propa_offset = propa_offset.view(batch, 2 * self.propagate_neighbors, height * width)
+            propa_grid = self.get_propagation_grid(batch, height, width, propa_offset, device, img)
 
         # the learned additional 2D offsets for adaptive spatial cost aggregation (adaptive evaluation)
         eval_offset = self.eval_conv(ref_feature)
@@ -715,7 +709,7 @@ class PatchMatch(nn.Module):
             weight = weight / torch.sum(weight, dim=2).unsqueeze(2)
 
             # evaluation, outputs regressed depth map
-            depth_sample, score = self.evaluation(
+            depth_sample, score, _ = self.evaluation(
                 ref_feature=ref_feature,
                 src_features=src_features,
                 ref_proj=ref_proj,
@@ -764,7 +758,7 @@ class PatchMatch(nn.Module):
             weight = weight / torch.sum(weight, dim=2).unsqueeze(2)
 
             # evaluation, outputs regressed depth map
-            depth_sample, score = self.evaluation(
+            depth_sample, score, _ = self.evaluation(
                 ref_feature=ref_feature,
                 src_features=src_features,
                 ref_proj=ref_proj,
@@ -927,8 +921,7 @@ def depth_weight(
     x1 = torch.clamp(x1, min=0, max=4)
     # sigmoid output approximate to 1 when x=4
     x1 = (-x1 + 2) * 2
-    output = nn.Sigmoid()
-    x1 = output(x1)
+    x1 = torch.sigmoid(x1)
 
     return x1.detach()
 

--- a/models/patchmatch.py
+++ b/models/patchmatch.py
@@ -377,7 +377,6 @@ class PatchMatch(nn.Module):
         self.evaluation = Evaluation(self.G, self.stage, self.evaluate_neighbors, self.patchmatch_iteration)
         # adaptive propagation
         # last iteration on stage 1 does not have propagation, but we still define this for TorchScript export compatibility
-        # This may have some impact on training! need to investigate
         self.propa_conv = nn.Conv2d(
             in_channels=self.propa_num_feature,
             out_channels=max(2 * self.propagate_neighbors, 1),

--- a/train.py
+++ b/train.py
@@ -43,7 +43,7 @@ parser.add_argument('--resume', action='store_true', help='continue to train the
 parser.add_argument('--summary_freq', type=int, default=20, help='print and summary frequency')
 parser.add_argument('--save_freq', type=int, default=1, help='save checkpoint frequency')
 parser.add_argument('--seed', type=int, default=1, metavar='S', help='random seed')
-
+parser.add_argument('--parallel', action='store_true', default=False, help='If set use DataParallel; this prevents TorchScript module export.')
 
 parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1,2,2], 
         help='num of iteration of patchmatch on stages 1,2,3')
@@ -98,7 +98,7 @@ model = PatchmatchNet(patchmatch_interval_scale=args.patchmatch_interval_scale,
                 propagation_range = args.patchmatch_range, patchmatch_iteration=args.patchmatch_iteration, 
                 patchmatch_num_sample = args.patchmatch_num_sample, 
                 propagate_neighbors=args.propagate_neighbors, evaluate_neighbors=args.evaluate_neighbors)
-if args.mode in ["train", "val"]:
+if args.parallel and args.mode in ["train", "val"]:
     model = nn.DataParallel(model)
 model.cuda()
 model_loss = patchmatchnet_loss
@@ -162,6 +162,11 @@ def train():
                 'model': model.state_dict(),
                 'optimizer': optimizer.state_dict()},
                 "{}/model_{:0>6}.ckpt".format(args.logdir, epoch_idx))
+            if not args.parallel:
+                model.eval()
+                sm = torch.jit.script(model)
+                sm.save(os.path.join(args.logdir, 'module_{:0>6}.pt'.format(epoch_idx)))
+                model.train()
 
         # testing
         avg_test_scalars = DictAverageMeter()
@@ -208,19 +213,15 @@ def train_sample(sample, detailed_summary=False):
     depth_gt = sample_cuda["depth"] 
     mask = sample_cuda["mask"]      
     
-    outputs = model(sample_cuda["imgs"], sample_cuda["proj_matrices"], 
-                        sample_cuda["depth_min"], sample_cuda["depth_max"])
-    
-    depth_est = outputs["refined_depth"]
-    
-    depth_patchmatch = outputs["depth_patchmatch"]
+    depth_est, _, depth_patchmatch = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
+                                           sample_cuda["depth_min"], sample_cuda["depth_max"])
 
     loss = model_loss(depth_patchmatch, depth_est, depth_gt, mask)
     loss.backward()
     optimizer.step()
 
     scalar_outputs = {"loss": loss}
-    image_outputs = {"depth_refined_stage_0": depth_est['stage_0'] * mask['stage_0'], 
+    image_outputs = {"depth_refined_stage_0": depth_est * mask['stage_0'],
                     "depth_gt_stage_0": depth_gt['stage_0'] * mask['stage_0'],
                     "depth_patchmatch_stage_1": depth_patchmatch['stage_1'][-1] * mask['stage_1'],
                     "depth_patchmatch_stage_2": depth_patchmatch['stage_2'][-1] * mask['stage_2'],
@@ -228,12 +229,12 @@ def train_sample(sample, detailed_summary=False):
                      "ref_img": sample["imgs"]['stage_0'][:, 0],
                      }
     if detailed_summary:
-        image_outputs["errormap_refined_stage_0"] = (depth_est['stage_0'] - depth_gt['stage_0']).abs() * mask['stage_0']
+        image_outputs["errormap_refined_stage_0"] = (depth_est - depth_gt['stage_0']).abs() * mask['stage_0']
         image_outputs["errormap_patchmatch_stage_1"] = (depth_patchmatch['stage_1'][-1] - depth_gt['stage_1']).abs() * mask['stage_1']
         image_outputs["errormap_patchmatch_stage_2"] = (depth_patchmatch['stage_2'][-1] - depth_gt['stage_2']).abs() * mask['stage_2']
         image_outputs["errormap_patchmatch_stage_3"] = (depth_patchmatch['stage_3'][-1] - depth_gt['stage_3']).abs() * mask['stage_3']
 
-    scalar_outputs["abs_depth_error_refined_stage_0"] = AbsDepthError_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5)
+    scalar_outputs["abs_depth_error_refined_stage_0"] = AbsDepthError_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5)
     scalar_outputs["abs_depth_error_patchmatch_stage_3"] = AbsDepthError_metrics(depth_patchmatch['stage_3'][-1], 
                                                         depth_gt['stage_3'], mask['stage_3'] > 0.5)
     scalar_outputs["abs_depth_error_patchmatch_stage_2"] = AbsDepthError_metrics(depth_patchmatch['stage_2'][-1], 
@@ -241,13 +242,13 @@ def train_sample(sample, detailed_summary=False):
     scalar_outputs["abs_depth_error_patchmatch_stage_1"] = AbsDepthError_metrics(depth_patchmatch['stage_1'][-1], 
                                                         depth_gt['stage_1'], mask['stage_1'] > 0.5)
     # threshold = 1mm
-    scalar_outputs["thres1mm_error"] = Thres_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5, 1)
+    scalar_outputs["thres1mm_error"] = Thres_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5, 1)
     # threshold = 2mm
-    scalar_outputs["thres2mm_error"] = Thres_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5, 2)
+    scalar_outputs["thres2mm_error"] = Thres_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5, 2)
     # threshold = 4mm
-    scalar_outputs["thres4mm_error"] = Thres_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5, 4)
+    scalar_outputs["thres4mm_error"] = Thres_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5, 4)
     # threshold = 8mm
-    scalar_outputs["thres8mm_error"] = Thres_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5, 8)
+    scalar_outputs["thres8mm_error"] = Thres_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5, 8)
     
     return tensor2float(loss), tensor2float(scalar_outputs), image_outputs
 
@@ -259,15 +260,12 @@ def test_sample(sample, detailed_summary=True):
     depth_gt = sample_cuda["depth"]
     mask = sample_cuda["mask"]
     
-    outputs = model(sample_cuda["imgs"], sample_cuda["proj_matrices"], 
-                        sample_cuda["depth_min"], sample_cuda["depth_max"])
-    
-    depth_est = outputs["refined_depth"]
-    depth_patchmatch = outputs["depth_patchmatch"]
+    depth_est, _, depth_patchmatch = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
+                                           sample_cuda["depth_min"], sample_cuda["depth_max"])
 
     loss = model_loss(depth_patchmatch, depth_est, depth_gt, mask)
     scalar_outputs = {"loss": loss}
-    image_outputs = {"depth_refined_stage_0": depth_est['stage_0'] * mask['stage_0'], 
+    image_outputs = {"depth_refined_stage_0": depth_est * mask['stage_0'],
                     "depth_gt_stage_0": depth_gt['stage_0'] * mask['stage_0'],
                     "depth_patchmatch_stage_1": depth_patchmatch['stage_1'][-1] * mask['stage_1'],
                     "depth_patchmatch_stage_2": depth_patchmatch['stage_2'][-1] * mask['stage_2'],
@@ -275,12 +273,12 @@ def test_sample(sample, detailed_summary=True):
                      "ref_img": sample["imgs"]['stage_0'][:, 0],
                      }
     if detailed_summary:
-        image_outputs["errormap_refined_stage_0"] = (depth_est['stage_0'] - depth_gt['stage_0']).abs() * mask['stage_0']
+        image_outputs["errormap_refined_stage_0"] = (depth_est - depth_gt['stage_0']).abs() * mask['stage_0']
         image_outputs["errormap_patchmatch_stage_1"] = (depth_patchmatch['stage_1'][-1] - depth_gt['stage_1']).abs() * mask['stage_1']
         image_outputs["errormap_patchmatch_stage_2"] = (depth_patchmatch['stage_2'][-1] - depth_gt['stage_2']).abs() * mask['stage_2']
         image_outputs["errormap_patchmatch_stage_3"] = (depth_patchmatch['stage_3'][-1] - depth_gt['stage_3']).abs() * mask['stage_3']
 
-    scalar_outputs["abs_depth_error_refined_stage_0"] = AbsDepthError_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5)
+    scalar_outputs["abs_depth_error_refined_stage_0"] = AbsDepthError_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5)
     scalar_outputs["abs_depth_error_patchmatch_stage_3"] = AbsDepthError_metrics(depth_patchmatch['stage_3'][-1], 
                                                         depth_gt['stage_3'], mask['stage_3'] > 0.5)
     scalar_outputs["abs_depth_error_patchmatch_stage_2"] = AbsDepthError_metrics(depth_patchmatch['stage_2'][-1], 
@@ -288,13 +286,13 @@ def test_sample(sample, detailed_summary=True):
     scalar_outputs["abs_depth_error_patchmatch_stage_1"] = AbsDepthError_metrics(depth_patchmatch['stage_1'][-1], 
                                                         depth_gt['stage_1'], mask['stage_1'] > 0.5)
     # threshold = 1mm
-    scalar_outputs["thres1mm_error"] = Thres_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5, 1)
+    scalar_outputs["thres1mm_error"] = Thres_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5, 1)
     # threshold = 2mm
-    scalar_outputs["thres2mm_error"] = Thres_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5, 2)
+    scalar_outputs["thres2mm_error"] = Thres_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5, 2)
     # threshold = 4mm
-    scalar_outputs["thres4mm_error"] = Thres_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5, 4)
+    scalar_outputs["thres4mm_error"] = Thres_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5, 4)
     # threshold = 8mm
-    scalar_outputs["thres8mm_error"] = Thres_metrics(depth_est['stage_0'], depth_gt['stage_0'], mask['stage_0'] > 0.5, 8)
+    scalar_outputs["thres8mm_error"] = Thres_metrics(depth_est, depth_gt['stage_0'], mask['stage_0'] > 0.5, 8)
     
     return tensor2float(loss), tensor2float(scalar_outputs), image_outputs
 


### PR DESCRIPTION
This is the minimal set of changes needed to allow exporting of the PatchMatchNet module as a TorschScript binary. This export enables use of PatchMatchNet in colmap and potentially other relevant software. The change is backwards compatible, by avoiding the strict loading of the state dictionary. Main changes include:
- Flag to explicitly enable DataParallel in training since this is not supported in TorchScript by default
  - Module is now exported alongside the checkpoints when DataParallel is off
- Removal of some `del ...` commands inside branches since TorchScript incorrectly marks these variables as undefined
- Remove Tensor initialization to `None` since it's not supported by TorchScript. When null initialization is needed a `torch.empty(0)` is used instead and the "null" check is done by `numel() == 0`.
- Some function output changes to only use TorchScript supported types (e.g. no `Union`)
- Declaration of nn modules only happens inside `__init__`
- No conditional members in `__init__`. This may lead to unused modules being declared, but it has no adverse impact on funcitonality.