### PR TITLE
Consolidate read/write operations in data_io

### DIFF
--- a/datasets/custom.py
+++ b/datasets/custom.py
@@ -1,70 +1,20 @@
 from torch.utils.data import Dataset
-from datasets.data_io import *
+from datasets.data_io import read_cam_file, read_pair_file, read_image
 import os
 import numpy as np
 import cv2
-from collections import defaultdict
-from PIL import Image
-import torch
-from torchvision import transforms as T
-import math
+
 
 class MVSDataset(Dataset):
-    def __init__(self, datapath, n_views=3, img_wh=(736,416)):
+    def __init__(self, datapath, n_views=3, img_wh=(736, 416)):
         
         self.stages = 4
         self.datapath = datapath
         self.img_wh = img_wh
         
-        self.build_metas()
+        self.metas = read_pair_file(os.path.join(self.datapath, 'pair.txt'))
         self.n_views = n_views
         
-
-    def build_metas(self):
-        self.metas = []
-        
-        with open(os.path.join(self.datapath, 'pair.txt')) as f:
-            num_viewpoint = int(f.readline())
-            for view_idx in range(num_viewpoint):
-                ref_view = int(f.readline().rstrip())
-                src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-                if len(src_views) != 0:
-                    self.metas += [(ref_view, src_views)]
-                    
-
-    def read_cam_file(self, filename):
-        with open(filename) as f:
-            lines = [line.rstrip() for line in f.readlines()]
-        # extrinsics: line [1,5), 4x4 matrix
-        extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ')
-        extrinsics = extrinsics.reshape((4, 4))
-        # intrinsics: line [7-10), 3x3 matrix
-        intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ')
-        intrinsics = intrinsics.reshape((3, 3))
-        
-        depth_min = float(lines[11].split()[0])
-        depth_max = float(lines[11].split()[1])
-
-        return intrinsics, extrinsics, depth_min, depth_max
-
-    def read_img(self, filename, h, w):
-        img = Image.open(filename)
-        
-        # scale 0~255 to 0~1
-        np_img = np.array(img, dtype=np.float32) / 255.
-        original_h, original_w, _ = np_img.shape
-        np_img = cv2.resize(np_img, self.img_wh, interpolation=cv2.INTER_LINEAR)
-        
-        np_img_ms = {
-            "stage_3": cv2.resize(np_img, (w//8, h//8), interpolation=cv2.INTER_LINEAR),
-            "stage_2": cv2.resize(np_img, (w//4, h//4), interpolation=cv2.INTER_LINEAR),
-            "stage_1": cv2.resize(np_img, (w//2, h//2), interpolation=cv2.INTER_LINEAR),
-            "stage_0": np_img
-        }
-        return np_img_ms, original_h, original_w
-
-    
-
     def __len__(self):
         return len(self.metas)
 
@@ -73,7 +23,6 @@ class MVSDataset(Dataset):
         ref_view, src_views = self.metas[idx]
         # use only the reference view and first nviews-1 source views
         view_ids = [ref_view] + src_views[:self.n_views-1]
-        
 
         imgs_0 = []
         imgs_1 = []
@@ -93,72 +42,58 @@ class MVSDataset(Dataset):
             img_filename = os.path.join(self.datapath, f'images/{vid:08d}.jpg')
             proj_mat_filename = os.path.join(self.datapath, f'cams/{vid:08d}_cam.txt')
 
-            imgs, original_h, original_w = self.read_img(img_filename,self.img_wh[1], self.img_wh[0])
-            imgs_0.append(imgs['stage_0'])
-            imgs_1.append(imgs['stage_1'])
-            imgs_2.append(imgs['stage_2'])
-            imgs_3.append(imgs['stage_3'])
-            
+            image, original_h, original_w = read_image(img_filename, max(self.img_wh))
+            imgs_0.append(image)
+            imgs_1.append(cv2.resize(image, (self.img_wh[0]//2, self.img_wh[1]//2), interpolation=cv2.INTER_LINEAR))
+            imgs_2.append(cv2.resize(image, (self.img_wh[0]//4, self.img_wh[1]//4), interpolation=cv2.INTER_LINEAR))
+            imgs_3.append(cv2.resize(image, (self.img_wh[0]//8, self.img_wh[1]//8), interpolation=cv2.INTER_LINEAR))
 
-            intrinsics, extrinsics, depth_min_, depth_max_ = self.read_cam_file(proj_mat_filename)
+            intrinsics, extrinsics, depth_params = read_cam_file(proj_mat_filename)
             intrinsics[0] *= self.img_wh[0]/original_w
             intrinsics[1] *= self.img_wh[1]/original_h
-            
-            
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 0.125
+            intrinsics[:2, :] *= 0.125
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_3.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_2.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_1.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_0.append(proj_mat)
 
-
             if i == 0:  # reference view
-                
-                depth_min = depth_min_
-                depth_max = depth_max_
-                
+                depth_min = depth_params[0]
+                depth_max = depth_params[1]
 
         # imgs: N*3*H0*W0, N is number of images
-        imgs_0 = np.stack(imgs_0).transpose([0, 3, 1, 2])
-        imgs_1 = np.stack(imgs_1).transpose([0, 3, 1, 2])
-        imgs_2 = np.stack(imgs_2).transpose([0, 3, 1, 2])
-        imgs_3 = np.stack(imgs_3).transpose([0, 3, 1, 2])
-        imgs = {}
-        imgs['stage_0'] = imgs_0
-        imgs['stage_1'] = imgs_1
-        imgs['stage_2'] = imgs_2
-        imgs['stage_3'] = imgs_3
+        imgs = {
+            'stage_0': np.stack(imgs_0).transpose([0, 3, 1, 2]),
+            'stage_1': np.stack(imgs_1).transpose([0, 3, 1, 2]),
+            'stage_2': np.stack(imgs_2).transpose([0, 3, 1, 2]),
+            'stage_3': np.stack(imgs_3).transpose([0, 3, 1, 2])
+        }
         # proj_matrices: N*4*4
-        proj_matrices_0 = np.stack(proj_matrices_0)
-        proj_matrices_1 = np.stack(proj_matrices_1)
-        proj_matrices_2 = np.stack(proj_matrices_2)
-        proj_matrices_3 = np.stack(proj_matrices_3)
-        proj={}
-        proj['stage_3']=proj_matrices_3
-        proj['stage_2']=proj_matrices_2
-        proj['stage_1']=proj_matrices_1
-        proj['stage_0']=proj_matrices_0
-        
-
+        proj = {
+            'stage_3': np.stack(proj_matrices_3),
+            'stage_2': np.stack(proj_matrices_2),
+            'stage_1': np.stack(proj_matrices_1),
+            'stage_0': np.stack(proj_matrices_0)
+        }
 
         return {"imgs": imgs,                   # N*3*H0*W0
-                "proj_matrices": proj, # N*4*4
+                "proj_matrices": proj,          # N*4*4
                 "depth_min": depth_min,         # scalar
-                "depth_max": depth_max,
+                "depth_max": depth_max,         # scalar
                 "filename": '{}/' + '{:0>8}'.format(view_ids[0]) + "{}"
-                }  
+                }

--- a/datasets/data_io.py
+++ b/datasets/data_io.py
@@ -1,10 +1,226 @@
-"""Utilities for reading and writing depth maps from/to disk."""
+"""Utilities for reading and writing images, depth maps, and auxiliary data (cams, pairs) from/to disk."""
 
 import re
+import struct
 import sys
-from typing import Tuple
+from typing import Dict, List, Tuple
 
+import cv2
 import numpy as np
+from PIL import Image
+
+
+def scale_to_max_dim(image: np.ndarray, max_dim: int) -> Tuple[np.ndarray, int, int]:
+    """Scale image to specified max dimension
+
+    Args:
+        image: the input image in original size
+        max_dim: the max dimension to scale the image down to if smaller than the actual max dimension
+
+    Returns:
+        Tuple of scaled image along with original image height and width
+    """
+    original_height = image.shape[0]
+    original_width = image.shape[1]
+    scale = max_dim / max(original_height, original_width)
+    if 0 < scale < 1:
+        width = int(scale * original_width)
+        height = int(scale * original_height)
+        image = cv2.resize(image, (width, height), interpolation=cv2.INTER_LINEAR)
+
+    return image, original_height, original_width
+
+
+def read_image(filename: str, max_dim: int = -1) -> Tuple[np.ndarray, int, int]:
+    """Read image and rescale to specified max dimension (if exists)
+
+    Args:
+        filename: image input file path string
+        max_dim: max dimension to scale down the image; keep original size if -1
+
+    Returns:
+        Tuple of scaled image along with original image height and width
+    """
+    image = Image.open(filename)
+    # scale 0~255 to 0~1
+    np_image = np.array(image, dtype=np.float32) / 255.0
+    return scale_to_max_dim(np_image, max_dim)
+
+
+def save_image(filename: str, image: np.ndarray) -> None:
+    """Save images including binary mask (bool), float (0<= val <= 1), or int (as-is)
+
+    Args:
+        filename: image output file path string
+        image: output image array
+    """
+    if image.dtype == bool:
+        image = image.astype(np.uint8) * 255
+    elif image.dtype == np.float32 or image.dtype == np.float64:
+        image = image * 255
+        image = image.astype(np.uint8)
+    else:
+        image = image.astype(np.uint8)
+    Image.fromarray(image).save(filename)
+
+
+def read_image_dictionary(filename: str) -> Dict[int, str]:
+    """Create image dictionary from file; useful for ETH3D dataset reading and conversion.
+
+    Args:
+        filename: input dictionary text file path
+
+    Returns:
+        Dictionary of image id (int) and corresponding image file name (string)
+    """
+    image_dict: Dict[int, str] = {}
+    with open(filename) as f:
+        num_entries = int(f.readline().strip())
+        for _ in range(num_entries):
+            parts = f.readline().strip().split(' ')
+            image_dict[int(parts[0].strip())] = parts[1].strip()
+    return image_dict
+
+
+def read_cam_file(filename: str) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Read camera intrinsics, extrinsics, and depth values (min, max) from text file
+
+    Args:
+        filename: cam text file path string
+
+    Returns:
+        Tuple with intrinsics matrix (3x3), extrinsics matrix (4x4), and depth params vector (min and max) if exists
+    """
+    with open(filename) as f:
+        lines = [line.rstrip() for line in f.readlines()]
+    # extrinsics: line [1,5), 4x4 matrix
+    extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ').reshape((4, 4))
+    # intrinsics: line [7-10), 3x3 matrix
+    intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ').reshape((3, 3))
+    # depth min and max: line 11
+    if len(lines) >= 12:
+        depth_params = np.fromstring(lines[11], dtype=np.float32, sep=' ')
+    else:
+        depth_params = np.empty(0)
+
+    return intrinsics, extrinsics, depth_params
+
+
+def read_pair_file(filename: str) -> List[Tuple[int, List[int]]]:
+    """Read image pairs from text file and output a list of tuples each containing the reference image ID and a list of
+    source image IDs
+
+    Args:
+        filename: pair text file path string
+
+    Returns:
+        List of tuples with reference ID and list of source IDs
+    """
+    data = []
+    with open(filename) as f:
+        num_viewpoint = int(f.readline())
+        for _ in range(num_viewpoint):
+            ref_view = int(f.readline().rstrip())
+            src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
+            if len(src_views) != 0:
+                data.append((ref_view, src_views))
+    return data
+
+
+def read_map(path: str, max_dim: int = -1) -> np.ndarray:
+    """ Read a binary depth map from either PFM or Colmap (bin) format determined by the file extension and also scale
+    the map to the max dim if given
+
+    Args:
+        path: input depth map file path string
+        max_dim: max dimension to scale down the map; keep original size if -1
+
+    Returns:
+        Array of depth map values
+    """
+    if path.endswith('.bin'):
+        in_map = read_bin(path)
+    elif path.endswith('.pfm'):
+        in_map, _ = read_pfm(path)
+    else:
+        raise Exception('Invalid input format; only pfm and bin are supported')
+    return scale_to_max_dim(in_map, max_dim)[0]
+
+
+def save_map(path: str, data: np.ndarray) -> None:
+    """Save binary depth or confidence maps in PFM or Colmap (bin) format determined by the file extension
+
+    Args:
+        path: output map file path string
+        data: map data array
+    """
+    if path.endswith('.bin'):
+        save_bin(path, data)
+    elif path.endswith('.pfm'):
+        save_pfm(path, data)
+    else:
+        raise Exception('Invalid input format; only pfm and bin are supported')
+
+
+def read_bin(path: str) -> np.ndarray:
+    """Read a depth map from a Colmap .bin file
+
+    Args:
+        path: .pfm file path string
+
+    Returns:
+        data: array of shape (H, W, C) representing loaded depth map
+    """
+    with open(path, 'rb') as fid:
+        width, height, channels = np.genfromtxt(fid, delimiter='&', max_rows=1,
+                                                usecols=(0, 1, 2), dtype=int)
+        fid.seek(0)
+        num_delimiter = 0
+        byte = fid.read(1)
+        while True:
+            if byte == b'&':
+                num_delimiter += 1
+                if num_delimiter >= 3:
+                    break
+            byte = fid.read(1)
+        data = np.fromfile(fid, np.float32)
+    data = data.reshape((width, height, channels), order='F')
+    data = np.transpose(data, (1, 0, 2))
+    return data
+
+
+def save_bin(filename: str, data: np.ndarray):
+    """Save a depth map to a Colmap .bin file
+
+    Args:
+        filename: output .pfm file path string,
+        data: depth map to save, of shape (H,W) or (H,W,C)
+    """
+    if data.dtype != np.float32:
+        raise Exception('Image data type must be float32.')
+
+    if len(data.shape) == 2:
+        height, width = data.shape
+        channels = 1
+    elif len(data.shape) == 3 and (data.shape[2] == 3 or data.shape[2] == 1):
+        height, width, channels = data.shape
+    else:
+        raise Exception('Image must have H x W x 3, H x W x 1 or H x W dimensions.')
+
+    with open(filename, 'w') as fid:
+        fid.write(str(width) + '&' + str(height) + '&' + str(channels) + '&')
+
+    with open(filename, 'ab') as fid:
+        if len(data.shape) == 2:
+            image_trans = np.transpose(data, (1, 0))
+        else:
+            image_trans = np.transpose(data, (1, 0, 2))
+        data_1d = image_trans.reshape(-1, order='F')
+        data_list = data_1d.tolist()
+        endian_character = '<'
+        format_char_sequence = ''.join(['f'] * len(data_list))
+        byte_data = struct.pack(endian_character + format_char_sequence, *data_list)
+        fid.write(byte_data)
 
 
 def read_pfm(filename: str) -> Tuple[np.ndarray, float]:
@@ -17,12 +233,7 @@ def read_pfm(filename: str) -> Tuple[np.ndarray, float]:
         data: array of shape (H, W, C) representing loaded depth map
         scale: float to recover actual depth map pixel values
     """
-    file = open(filename, "rb") # treat as binary and read-only
-    color = None
-    width = None
-    height = None
-    scale = None
-    endian = None
+    file = open(filename, "rb")  # treat as binary and read-only
 
     header = file.readline().decode("utf-8").rstrip()
     if header == "PF":
@@ -55,7 +266,7 @@ def read_pfm(filename: str) -> Tuple[np.ndarray, float]:
 
 
 def save_pfm(filename: str, image: np.ndarray, scale: float = 1) -> None:
-    """Save a depth map from a .pfm file
+    """Save a depth map to a .pfm file
 
     Args:
         filename: output .pfm file path string,

--- a/datasets/dtu_yao.py
+++ b/datasets/dtu_yao.py
@@ -1,122 +1,74 @@
 from torch.utils.data import Dataset
+from datasets.data_io import read_cam_file, read_pair_file, read_image, read_map
+from typing import List, Tuple
+from PIL import Image
 import numpy as np
 import os
-from PIL import Image
-from datasets.data_io import *
 import cv2
 import random
 
 
+def prepare_img(hr_img):
+    # original w,h: 1600, 1200; downsample -> 800, 600 ; crop -> 640, 512
+    # downsample
+    h, w = hr_img.shape
+    hr_img_ds = cv2.resize(hr_img, (w//2, h//2), interpolation=cv2.INTER_NEAREST)
+    # crop
+    h, w = hr_img_ds.shape
+    target_h, target_w = 512, 640
+    start_h, start_w = (h - target_h)//2, (w - target_w)//2
+    hr_img_crop = hr_img_ds[start_h: start_h + target_h, start_w: start_w + target_w]
+
+    return hr_img_crop
+
+
+def read_depth_mask(stages, filename, mask_filename, depth_min, depth_max):
+    depth = np.array(read_map(filename), dtype=np.float32)
+    depth = prepare_img(np.squeeze(depth, 2))
+
+    mask = np.array(Image.open(mask_filename), dtype=np.float32)
+    mask = (mask > 10).astype(np.float32)
+    mask = prepare_img(mask).astype(bool)
+    mask = mask & (depth >= depth_min) & (depth <= depth_max)
+    mask = mask.astype(np.float32)
+
+    h, w = depth.shape
+    depth_ms = {}
+    mask_ms = {}
+
+    for i in range(stages):
+        depth_cur = cv2.resize(depth, (w//(2**i), h//(2**i)), interpolation=cv2.INTER_NEAREST)
+        mask_cur = cv2.resize(mask, (w//(2**i), h//(2**i)), interpolation=cv2.INTER_NEAREST)
+        depth_ms[f"stage_{i}"] = depth_cur
+        mask_ms[f"stage_{i}"] = mask_cur
+
+    return depth_ms, mask_ms
+
+
 class MVSDataset(Dataset):
-    def __init__(self, datapath, listfile, mode, nviews, robust_train = False):
+    def __init__(self, datapath, listfile, mode, nviews, robust_train=False):
         super(MVSDataset, self).__init__()
 
         self.stages = 4
         self.datapath = datapath
-        self.listfile = listfile
-        self.mode = mode
         self.nviews = nviews
-        
         self.robust_train = robust_train
-        
 
-        assert self.mode in ["train", "val", "test"]
-        self.metas = self.build_list()
+        assert mode in ["train", "val", "test"]
 
-    def build_list(self):
-        metas = []
-        with open(self.listfile) as f:
+        with open(listfile) as f:
             scans = f.readlines()
             scans = [line.rstrip() for line in scans]
 
+        self.metas: List[Tuple[str, int, int, List[int]]] = []
         for scan in scans:
-            pair_file = "Cameras_1/pair.txt"
-            
-            with open(os.path.join(self.datapath, pair_file)) as f:
-                self.num_viewpoint = int(f.readline())
-                # viewpoints (49)
-                for view_idx in range(self.num_viewpoint):
-                    ref_view = int(f.readline().rstrip())
-                    src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-                    # light conditions 0-6
-                    for light_idx in range(7):
-                        metas.append((scan, light_idx, ref_view, src_views))
-        print("dataset", self.mode, "metas:", len(metas))
-        return metas
+            pair_data = read_pair_file(os.path.join(self.datapath, "Cameras_1/pair.txt"))
+            for light_idx in range(7):
+                self.metas += [(scan, light_idx, ref, src) for ref, src in pair_data]
+        print("dataset", mode, "metas:", len(self.metas))
 
     def __len__(self):
         return len(self.metas)
-
-    def read_cam_file(self, filename):
-        with open(filename) as f:
-            lines = f.readlines()
-            lines = [line.rstrip() for line in lines]
-        # extrinsics: line [1,5), 4x4 matrix
-        extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ').reshape((4, 4))
-        # intrinsics: line [7-10), 3x3 matrix
-        intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ').reshape((3, 3))
-        
-        depth_min = float(lines[11].split()[0])
-        depth_max = float(lines[11].split()[1])
-        return intrinsics, extrinsics, depth_min, depth_max
-
-    def read_img(self, filename):
-        img = Image.open(filename)
-        # scale 0~255 to 0~1
-        np_img = np.array(img, dtype=np.float32) / 255.
-        h, w, _ = np_img.shape
-        np_img_ms = {
-            "stage_3": cv2.resize(np_img, (w//8, h//8), interpolation=cv2.INTER_LINEAR), 
-            "stage_2": cv2.resize(np_img, (w//4, h//4), interpolation=cv2.INTER_LINEAR),
-            "stage_1": cv2.resize(np_img, (w//2, h//2), interpolation=cv2.INTER_LINEAR),
-            "stage_0": np_img
-        }
-        return np_img_ms
-        
-    def read_depth(self, filename):
-        return np.array(read_pfm(filename)[0], dtype=np.float32)
-
-    def prepare_img(self, hr_img):
-        # original w,h: 1600, 1200; downsample -> 800, 600 ; crop -> 640, 512
-        #downsample
-        h, w = hr_img.shape
-        hr_img_ds = cv2.resize(hr_img, (w//2, h//2), interpolation=cv2.INTER_NEAREST)
-        #crop
-        h, w = hr_img_ds.shape
-        target_h, target_w = 512, 640
-        start_h, start_w = (h - target_h)//2, (w - target_w)//2
-        hr_img_crop = hr_img_ds[start_h: start_h + target_h, start_w: start_w + target_w]
-
-        return hr_img_crop
-
-    def read_mask(self, filename):
-        img = Image.open(filename)
-        np_img = np.array(img, dtype=np.float32)
-        np_img = (np_img > 10).astype(np.float32)
-        return np_img
-
-    def read_depth_mask(self, filename, mask_filename, depth_min, depth_max):
-        depth_hr = np.array(read_pfm(filename)[0], dtype=np.float32)
-        depth_hr = np.squeeze(depth_hr,2)
-        depth_lr = self.prepare_img(depth_hr)
-
-        mask = self.read_mask(mask_filename)
-        mask = self.prepare_img(mask)
-        mask = mask.astype(np.bool_)
-        mask = mask & (depth_lr>=depth_min) & (depth_lr<=depth_max)
-        mask = mask.astype(np.float32)
-
-        h, w = depth_lr.shape
-        depth_lr_ms = {}
-        mask_ms = {}
-
-        for i in range(self.stages):
-            depth_cur = cv2.resize(depth_lr, (w//(2**i), h//(2**i)), interpolation=cv2.INTER_NEAREST)
-            mask_cur = cv2.resize(mask, (w//(2**i), h//(2**i)), interpolation=cv2.INTER_NEAREST)
-            depth_lr_ms[f"stage_{i}"] = depth_cur
-            mask_ms[f"stage_{i}"] = mask_cur
-
-        return depth_lr_ms, mask_ms
 
     def __getitem__(self, idx):
         meta = self.metas[idx]
@@ -127,7 +79,6 @@ class MVSDataset(Dataset):
             num_src_views = len(src_views)
             index = random.sample(range(num_src_views), self.nviews - 1)
             view_ids = [ref_view] + [src_views[i] for i in index]
-
         else:
             view_ids = [ref_view] + src_views[:self.nviews - 1]
 
@@ -145,91 +96,73 @@ class MVSDataset(Dataset):
         proj_matrices_1 = []
         proj_matrices_2 = []
         proj_matrices_3 = []
-        
 
         for i, vid in enumerate(view_ids):
             # NOTE that the id in image file names is from 1 to 49 (not 0~48)
-            img_filename = os.path.join(self.datapath,
-                                        'Rectified/{}_train/rect_{:0>3}_{}_r5000.png'.format(scan, vid + 1, light_idx))
-            
+            img_filename = os.path.join(
+                self.datapath, 'Rectified/{}_train/rect_{:0>3}_{}_r5000.png'.format(scan, vid + 1, light_idx))
             mask_filename_hr = os.path.join(self.datapath, 'Depths_raw/{}/depth_visual_{:0>4}.png'.format(scan, vid))
             depth_filename_hr = os.path.join(self.datapath, 'Depths_raw/{}/depth_map_{:0>4}.pfm'.format(scan, vid))
             proj_mat_filename = os.path.join(self.datapath, 'Cameras_1/train/{:0>8}_cam.txt').format(vid)
 
-            imgs = self.read_img(img_filename)
-            imgs_0.append(imgs['stage_0'])
-            imgs_1.append(imgs['stage_1'])
-            imgs_2.append(imgs['stage_2'])
-            imgs_3.append(imgs['stage_3'])
+            image, original_h, original_w = read_image(img_filename)
+            imgs_0.append(image)
+            imgs_1.append(cv2.resize(image, (original_w//2, original_h//2), interpolation=cv2.INTER_LINEAR))
+            imgs_2.append(cv2.resize(image, (original_w//4, original_h//4), interpolation=cv2.INTER_LINEAR))
+            imgs_3.append(cv2.resize(image, (original_w//8, original_h//8), interpolation=cv2.INTER_LINEAR))
 
             # here, the intrinsics from file is already adjusted to the downsampled size of feature 1/4H0 * 1/4W0
-            intrinsics, extrinsics, depth_min_, depth_max_ = self.read_cam_file(proj_mat_filename)
+            intrinsics, extrinsics, depth_params = read_cam_file(proj_mat_filename)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 0.5
+            intrinsics[:2, :] *= 0.5
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_3.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_2.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_1.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_0.append(proj_mat)
 
             if i == 0:  # reference view
-                depth_min = depth_min_
-                depth_max = depth_max_
-                depth, mask = self.read_depth_mask(depth_filename_hr, mask_filename_hr, depth_min, depth_max)
-                for l in range(self.stages):
-                    mask[f'stage_{l}'] = np.expand_dims(mask[f'stage_{l}'],2)
-                    mask[f'stage_{l}'] = mask[f'stage_{l}'].transpose([2,0,1])
-                    depth[f'stage_{l}'] = np.expand_dims(depth[f'stage_{l}'],2)
-                    depth[f'stage_{l}'] = depth[f'stage_{l}'].transpose([2,0,1])
-                
-                
+                depth_min = depth_params[0]
+                depth_max = depth_params[1]
+                depth, mask = read_depth_mask(self.stages, depth_filename_hr, mask_filename_hr, depth_min, depth_max)
+                for j in range(self.stages):
+                    mask[f'stage_{j}'] = np.expand_dims(mask[f'stage_{j}'], 2)
+                    mask[f'stage_{j}'] = mask[f'stage_{j}'].transpose([2, 0, 1])
+                    depth[f'stage_{j}'] = np.expand_dims(depth[f'stage_{j}'], 2)
+                    depth[f'stage_{j}'] = depth[f'stage_{j}'].transpose([2, 0, 1])
 
-                
         # imgs: N*3*H0*W0, N is number of images
-        imgs_0 = np.stack(imgs_0).transpose([0, 3, 1, 2])
-        imgs_1 = np.stack(imgs_1).transpose([0, 3, 1, 2])
-        imgs_2 = np.stack(imgs_2).transpose([0, 3, 1, 2])
-        imgs_3 = np.stack(imgs_3).transpose([0, 3, 1, 2])
-        
-        imgs = {}
-        imgs['stage_0'] = imgs_0
-        imgs['stage_1'] = imgs_1
-        imgs['stage_2'] = imgs_2
-        imgs['stage_3'] = imgs_3
-        
+        imgs = {
+            'stage_0': np.stack(imgs_0).transpose([0, 3, 1, 2]),
+            'stage_1': np.stack(imgs_1).transpose([0, 3, 1, 2]),
+            'stage_2': np.stack(imgs_2).transpose([0, 3, 1, 2]),
+            'stage_3': np.stack(imgs_3).transpose([0, 3, 1, 2])
+        }
         # proj_matrices: N*4*4
-        proj_matrices_0 = np.stack(proj_matrices_0)
-        proj_matrices_1 = np.stack(proj_matrices_1)
-        proj_matrices_2 = np.stack(proj_matrices_2)
-        proj_matrices_3 = np.stack(proj_matrices_3)
-        
-        proj={}
-        proj['stage_3']=proj_matrices_3
-        proj['stage_2']=proj_matrices_2
-        proj['stage_1']=proj_matrices_1
-        proj['stage_0']=proj_matrices_0
-        
+        proj = {
+            'stage_3': np.stack(proj_matrices_3),
+            'stage_2': np.stack(proj_matrices_2),
+            'stage_1': np.stack(proj_matrices_1),
+            'stage_0': np.stack(proj_matrices_0)
+        }
 
-
-        
         # data is numpy array
         return {"imgs": imgs,                   # N*3*H0*W0
-                "proj_matrices": proj, # N*4*4
-                "depth": depth,                 # 1*H0 * W0
+                "proj_matrices": proj,          # N*4*4
+                "depth": depth,                 # 1*H0*W0
                 "depth_min": depth_min,         # scalar
                 "depth_max": depth_max,         # scalar
-                "mask": mask}                   # 1*H0 * W0
-
+                "mask": mask}                   # 1*H0*W0

--- a/datasets/dtu_yao_eval.py
+++ b/datasets/dtu_yao_eval.py
@@ -1,80 +1,34 @@
 from torch.utils.data import Dataset
+from datasets.data_io import read_cam_file, read_pair_file, read_image
+from typing import List, Tuple
 import numpy as np
 import os
-from PIL import Image
-from datasets.data_io import *
 import cv2
 
 
 class MVSDataset(Dataset):
-    def __init__(self, datapath, listfile, mode, nviews, img_wh=(1600, 1200), **kwargs):
+    def __init__(self, datapath, listfile, mode, nviews, img_wh=(1600, 1200)):
         super(MVSDataset, self).__init__()
         
         self.stages = 4
         self.datapath = datapath
-        self.listfile = listfile
-        self.mode = mode
         self.nviews = nviews
         self.img_wh = img_wh
-        
 
-        assert self.mode == "test"
-        self.metas = self.build_list()
+        assert mode == "test"
 
-    def build_list(self):
-        metas = []
-        with open(self.listfile) as f:
+        with open(listfile) as f:
             scans = f.readlines()
             scans = [line.rstrip() for line in scans]
-            
-                  
+
+        self.metas: List[Tuple[str, int, List[int]]] = []
         for scan in scans:
-            pair_file = "{}/pair.txt".format(scan)
-            # read the pair file
-            with open(os.path.join(self.datapath, pair_file)) as f:
-                num_viewpoint = int(f.readline())
-                # viewpoints (49)
-                for view_idx in range(num_viewpoint):
-                    ref_view = int(f.readline().rstrip())
-                    src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-                    metas.append((scan, ref_view, src_views))
-        print("dataset", self.mode, "metas:", len(metas))
-        return metas
+            pair_data = read_pair_file(os.path.join(self.datapath, scan, 'pair.txt'))
+            self.metas += [(scan, ref, src) for ref, src in pair_data]
+        print("dataset", mode, "metas:", len(self.metas))
 
     def __len__(self):
         return len(self.metas)
-
-    def read_cam_file(self, filename):
-        with open(filename) as f:
-            lines = f.readlines()
-            lines = [line.rstrip() for line in lines]
-        # extrinsics: line [1,5), 4x4 matrix
-        extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ').reshape((4, 4))
-        # intrinsics: line [7-10), 3x3 matrix
-        intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ').reshape((3, 3))
-
-        depth_min = float(lines[11].split()[0])
-        depth_max = float(lines[11].split()[1])
-        return intrinsics, extrinsics, depth_min, depth_max
-
-    
-    def read_img(self, filename):
-        img = Image.open(filename)
-        # scale 0~255 to 0~1
-        np_img = np.array(img, dtype=np.float32) / 255.
-        np_img = cv2.resize(np_img, self.img_wh, interpolation=cv2.INTER_LINEAR)
-        
-        h, w, _ = np_img.shape
-        
-        np_img_ms = {
-            "stage_3": cv2.resize(np_img, (w//8, h//8), interpolation=cv2.INTER_LINEAR),
-            "stage_2": cv2.resize(np_img, (w//4, h//4), interpolation=cv2.INTER_LINEAR),
-            "stage_1": cv2.resize(np_img, (w//2, h//2), interpolation=cv2.INTER_LINEAR),
-            "stage_0": np_img
-        }
-        return np_img_ms
-        
-
 
     def __getitem__(self, idx):
         meta = self.metas[idx]
@@ -99,63 +53,57 @@ class MVSDataset(Dataset):
             img_filename = os.path.join(self.datapath, '{}/images/{:0>8}.jpg'.format(scan, vid))
             proj_mat_filename = os.path.join(self.datapath, '{}/cams_1/{:0>8}_cam.txt'.format(scan, vid))
 
-            imgs = self.read_img(img_filename)
-            imgs_0.append(imgs['stage_0'])
-            imgs_1.append(imgs['stage_1'])
-            imgs_2.append(imgs['stage_2'])
-            imgs_3.append(imgs['stage_3'])
+            image, original_h, original_w = read_image(img_filename, max(self.img_wh))
+            imgs_0.append(image)
+            imgs_1.append(cv2.resize(image, (self.img_wh[0]//2, self.img_wh[1]//2), interpolation=cv2.INTER_LINEAR))
+            imgs_2.append(cv2.resize(image, (self.img_wh[0]//4, self.img_wh[1]//4), interpolation=cv2.INTER_LINEAR))
+            imgs_3.append(cv2.resize(image, (self.img_wh[0]//8, self.img_wh[1]//8), interpolation=cv2.INTER_LINEAR))
 
-            intrinsics, extrinsics, depth_min_, depth_max_ = self.read_cam_file(proj_mat_filename)
+            intrinsics, extrinsics, depth_params = read_cam_file(proj_mat_filename)
             intrinsics[0] *= self.img_wh[0]/img_w
             intrinsics[1] *= self.img_wh[1]/img_h
             # multiply intrinsics and extrinsics to get projection matrix
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 0.125
+            intrinsics[:2, :] *= 0.125
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_3.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_2.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_1.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_0.append(proj_mat)
 
-
             if i == 0:  # reference view
-                depth_min = depth_min_
-                depth_max = depth_max_
+                depth_min = depth_params[0]
+                depth_max = depth_params[1]
 
-        imgs_0 = np.stack(imgs_0).transpose([0, 3, 1, 2])
-        imgs_1 = np.stack(imgs_1).transpose([0, 3, 1, 2])
-        imgs_2 = np.stack(imgs_2).transpose([0, 3, 1, 2])
-        imgs_3 = np.stack(imgs_3).transpose([0, 3, 1, 2])
-        imgs = {}
-        imgs['stage_0'] = imgs_0
-        imgs['stage_1'] = imgs_1
-        imgs['stage_2'] = imgs_2
-        imgs['stage_3'] = imgs_3
+        # imgs: N*3*H0*W0, N is number of images
+        imgs = {
+            'stage_0': np.stack(imgs_0).transpose([0, 3, 1, 2]),
+            'stage_1': np.stack(imgs_1).transpose([0, 3, 1, 2]),
+            'stage_2': np.stack(imgs_2).transpose([0, 3, 1, 2]),
+            'stage_3': np.stack(imgs_3).transpose([0, 3, 1, 2])
+        }
         # proj_matrices: N*4*4
-        proj_matrices_0 = np.stack(proj_matrices_0)
-        proj_matrices_1 = np.stack(proj_matrices_1)
-        proj_matrices_2 = np.stack(proj_matrices_2)
-        proj_matrices_3 = np.stack(proj_matrices_3)
-        proj={}
-        proj['stage_3']=proj_matrices_3
-        proj['stage_2']=proj_matrices_2
-        proj['stage_1']=proj_matrices_1
-        proj['stage_0']=proj_matrices_0
+        proj = {
+            'stage_3': np.stack(proj_matrices_3),
+            'stage_2': np.stack(proj_matrices_2),
+            'stage_1': np.stack(proj_matrices_1),
+            'stage_0': np.stack(proj_matrices_0)
+        }
 
         return {"imgs": imgs,                   # N*3*H0*W0
-                "proj_matrices": proj, # N*4*4
+                "proj_matrices": proj,          # N*4*4
                 "depth_min": depth_min,         # scalar
                 "depth_max": depth_max,         # scalar
                 "filename": scan + '/{}/' + '{:0>8}'.format(view_ids[0]) + "{}"}

--- a/datasets/eth3d.py
+++ b/datasets/eth3d.py
@@ -1,93 +1,41 @@
 from torch.utils.data import Dataset
-from datasets.data_io import *
+from datasets.data_io import read_cam_file, read_pair_file, read_image
+from typing import List, Tuple
 import os
 import numpy as np
 import cv2
-from collections import defaultdict
-from PIL import Image
-import torch
-from torchvision import transforms as T
-import math
+
 
 class MVSDataset(Dataset):
-    def __init__(self, datapath, split='test', n_views=3, img_wh=(2688,1792)):
+    def __init__(self, datapath, split='test', n_views=3, img_wh=(2688, 1792)):
         
         self.stages = 4
         self.datapath = datapath
         self.img_wh = img_wh
-        self.split = split
-        
-        self.build_metas()
         self.n_views = n_views
-        
 
-    def build_metas(self):
-        self.metas = []
-        if self.split == "test":
-            self.scans = ['botanical_garden', 'boulders', 'bridge', 'door',
-                'exhibition_hall', 'lecture_room', 'living_room', 'lounge',
-                'observatory', 'old_computer', 'statue', 'terrace_2']
+        scans = []
+        if split == "test":
+            scans = ['botanical_garden', 'boulders', 'bridge', 'door', 'exhibition_hall', 'lecture_room', 'living_room',
+                     'lounge', 'observatory', 'old_computer', 'statue', 'terrace_2']
 
-        elif self.split == "train":
-            self.scans = ['courtyard', 'delivery_area', 'electro', 'facade',
-                    'kicker', 'meadow', 'office', 'pipes', 'playground',
-                    'relief', 'relief_2', 'terrace', 'terrains']
-        
+        elif split == "train":
+            scans = ['courtyard', 'delivery_area', 'electro', 'facade', 'kicker', 'meadow', 'office', 'pipes',
+                     'playground', 'relief', 'relief_2', 'terrace', 'terrains']
 
-        for scan in self.scans:
-            with open(os.path.join(self.datapath, scan, 'pair.txt')) as f:
-                num_viewpoint = int(f.readline())
-                for view_idx in range(num_viewpoint):
-                    ref_view = int(f.readline().rstrip())
-                    src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-                    if len(src_views) != 0:
-                        self.metas += [(scan, -1, ref_view, src_views)]
-                    
-
-    def read_cam_file(self, filename):
-        with open(filename) as f:
-            lines = [line.rstrip() for line in f.readlines()]
-        # extrinsics: line [1,5), 4x4 matrix
-        extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ')
-        extrinsics = extrinsics.reshape((4, 4))
-        # intrinsics: line [7-10), 3x3 matrix
-        intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ')
-        intrinsics = intrinsics.reshape((3, 3))
-        
-        depth_min = float(lines[11].split()[0])
-        if depth_min < 0: # for botanical garden, exist incorrect value
-            depth_min = 1
-        depth_max = float(lines[11].split()[1])
-
-        return intrinsics, extrinsics, depth_min, depth_max
-
-    def read_img(self, filename, h, w):
-        img = Image.open(filename)
-        
-        # scale 0~255 to 0~1
-        np_img = np.array(img, dtype=np.float32) / 255.
-        original_h, original_w, _ = np_img.shape
-        np_img = cv2.resize(np_img, self.img_wh, interpolation=cv2.INTER_LINEAR)
-        
-        np_img_ms = {
-            "stage_3": cv2.resize(np_img, (w//8, h//8), interpolation=cv2.INTER_LINEAR),
-            "stage_2": cv2.resize(np_img, (w//4, h//4), interpolation=cv2.INTER_LINEAR),
-            "stage_1": cv2.resize(np_img, (w//2, h//2), interpolation=cv2.INTER_LINEAR),
-            "stage_0": np_img
-        }
-        return np_img_ms, original_h, original_w
-
-    
+        self.metas: List[Tuple[str, int, List[int]]] = []
+        for scan in scans:
+            pair_data = read_pair_file(os.path.join(self.datapath, scan, 'pair.txt'))
+            self.metas += [(scan, ref, src) for ref, src in pair_data]
 
     def __len__(self):
         return len(self.metas)
 
     def __getitem__(self, idx):
         
-        scan, _, ref_view, src_views = self.metas[idx]
+        scan, ref_view, src_views = self.metas[idx]
         # use only the reference view and first nviews-1 source views
         view_ids = [ref_view] + src_views[:self.n_views-1]
-        
 
         imgs_0 = []
         imgs_1 = []
@@ -107,72 +55,60 @@ class MVSDataset(Dataset):
             img_filename = os.path.join(self.datapath,  scan, f'images/{vid:08d}.jpg')
             proj_mat_filename = os.path.join(self.datapath, scan, f'cams_1/{vid:08d}_cam.txt')
 
-            imgs, original_h, original_w = self.read_img(img_filename,self.img_wh[1], self.img_wh[0])
-            imgs_0.append(imgs['stage_0'])
-            imgs_1.append(imgs['stage_1'])
-            imgs_2.append(imgs['stage_2'])
-            imgs_3.append(imgs['stage_3'])
-            
+            image, original_h, original_w = read_image(img_filename, max(self.img_wh))
+            imgs_0.append(image)
+            imgs_1.append(cv2.resize(image, (self.img_wh[0]//2, self.img_wh[1]//2), interpolation=cv2.INTER_LINEAR))
+            imgs_2.append(cv2.resize(image, (self.img_wh[0]//4, self.img_wh[1]//4), interpolation=cv2.INTER_LINEAR))
+            imgs_3.append(cv2.resize(image, (self.img_wh[0]//8, self.img_wh[1]//8), interpolation=cv2.INTER_LINEAR))
 
-            intrinsics, extrinsics, depth_min_, depth_max_ = self.read_cam_file(proj_mat_filename)
+            intrinsics, extrinsics, depth_params = read_cam_file(proj_mat_filename)
             intrinsics[0] *= self.img_wh[0]/original_w
             intrinsics[1] *= self.img_wh[1]/original_h
-            
-            
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 0.125
+            intrinsics[:2, :] *= 0.125
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_3.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_2.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_1.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_0.append(proj_mat)
 
-
             if i == 0:  # reference view
-                
-                depth_min = depth_min_
-                depth_max = depth_max_
-                
+                # for botanical garden there is an incorrect depth value - not observed in current data
+                # depth_min = depth_params[0] if depth_params[0] >= 0 else 1.0
+                depth_min = depth_params[0]
+                depth_max = depth_params[1]
 
         # imgs: N*3*H0*W0, N is number of images
-        imgs_0 = np.stack(imgs_0).transpose([0, 3, 1, 2])
-        imgs_1 = np.stack(imgs_1).transpose([0, 3, 1, 2])
-        imgs_2 = np.stack(imgs_2).transpose([0, 3, 1, 2])
-        imgs_3 = np.stack(imgs_3).transpose([0, 3, 1, 2])
-        imgs = {}
-        imgs['stage_0'] = imgs_0
-        imgs['stage_1'] = imgs_1
-        imgs['stage_2'] = imgs_2
-        imgs['stage_3'] = imgs_3
+        imgs = {
+            'stage_0': np.stack(imgs_0).transpose([0, 3, 1, 2]),
+            'stage_1': np.stack(imgs_1).transpose([0, 3, 1, 2]),
+            'stage_2': np.stack(imgs_2).transpose([0, 3, 1, 2]),
+            'stage_3': np.stack(imgs_3).transpose([0, 3, 1, 2])
+        }
         # proj_matrices: N*4*4
-        proj_matrices_0 = np.stack(proj_matrices_0)
-        proj_matrices_1 = np.stack(proj_matrices_1)
-        proj_matrices_2 = np.stack(proj_matrices_2)
-        proj_matrices_3 = np.stack(proj_matrices_3)
-        proj={}
-        proj['stage_3']=proj_matrices_3
-        proj['stage_2']=proj_matrices_2
-        proj['stage_1']=proj_matrices_1
-        proj['stage_0']=proj_matrices_0
-        
-
+        proj = {
+            'stage_3': np.stack(proj_matrices_3),
+            'stage_2': np.stack(proj_matrices_2),
+            'stage_1': np.stack(proj_matrices_1),
+            'stage_0': np.stack(proj_matrices_0)
+        }
 
         return {"imgs": imgs,                   # N*3*H0*W0
-                "proj_matrices": proj, # N*4*4
+                "proj_matrices": proj,          # N*4*4
                 "depth_min": depth_min,         # scalar
-                "depth_max": depth_max,
+                "depth_max": depth_max,         # scalar
                 "filename": scan + '/{}/' + '{:0>8}'.format(view_ids[0]) + "{}"
                 }  

--- a/datasets/tanks.py
+++ b/datasets/tanks.py
@@ -1,13 +1,10 @@
 from torch.utils.data import Dataset
-from datasets.data_io import *
+from datasets.data_io import read_cam_file, read_pair_file, read_image
+from typing import List, Tuple
 import os
 import numpy as np
 import cv2
-from collections import defaultdict
-from PIL import Image
-import torch
-from torchvision import transforms as T
-import math
+
 
 class MVSDataset(Dataset):
     def __init__(self, datapath, split='intermediate', n_views=3, img_wh=(1920, 1056)):
@@ -15,19 +12,12 @@ class MVSDataset(Dataset):
         self.stages = 4
         self.datapath = datapath
         self.img_wh = img_wh
-        
         self.split = split
-        self.build_metas()
         self.n_views = n_views
-        
 
-    def build_metas(self):
-        self.metas = []
+        scans = []
         if self.split == 'intermediate':
-            self.scans = ['Family', 'Francis', 'Horse', 'Lighthouse',
-                          'M60', 'Panther', 'Playground', 'Train']
-            
-            
+            scans = ['Family', 'Francis', 'Horse', 'Lighthouse', 'M60', 'Panther', 'Playground', 'Train']
             self.image_sizes = {'Family': (1920, 1080),
                                 'Francis': (1920, 1080),
                                 'Horse': (1920, 1080),
@@ -36,65 +26,26 @@ class MVSDataset(Dataset):
                                 'Panther': (2048, 1080),
                                 'Playground': (1920, 1080),
                                 'Train': (1920, 1080)}
-            
         elif self.split == 'advanced':
-            self.scans = ['Auditorium', 'Ballroom', 'Courtroom',
-                          'Museum', 'Palace', 'Temple']
+            scans = ['Auditorium', 'Ballroom', 'Courtroom', 'Museum', 'Palace', 'Temple']
             self.image_sizes = {'Auditorium': (1920, 1080),
                                 'Ballroom': (1920, 1080),
                                 'Courtroom': (1920, 1080),
                                 'Museum': (1920, 1080),
                                 'Palace': (1920, 1080),
                                 'Temple': (1920, 1080)}
-            
-        
 
-        for scan in self.scans:
-            with open(os.path.join(self.datapath, self.split, scan, 'pair.txt')) as f:
-                num_viewpoint = int(f.readline())
-                for view_idx in range(num_viewpoint):
-                    ref_view = int(f.readline().rstrip())
-                    src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-                    if len(src_views) != 0:
-                        self.metas += [(scan, -1, ref_view, src_views)]
-   
-    def read_cam_file(self, filename):
-        with open(filename) as f:
-            lines = [line.rstrip() for line in f.readlines()]
-        # extrinsics: line [1,5), 4x4 matrix
-        extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ')
-        extrinsics = extrinsics.reshape((4, 4))
-        # intrinsics: line [7-10), 3x3 matrix
-        intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ')
-        intrinsics = intrinsics.reshape((3, 3))
-        
-        depth_min = float(lines[11].split()[0])
-        depth_max = float(lines[11].split()[1])
-
-        return intrinsics, extrinsics, depth_min, depth_max
-
-    def read_img(self, filename, h, w):
-        img = Image.open(filename)
-        # scale 0~255 to 0~1
-        np_img = np.array(img, dtype=np.float32) / 255.
-        np_img = cv2.resize(np_img, self.img_wh, interpolation=cv2.INTER_LINEAR)
-        
-        np_img_ms = {
-            "stage_3": cv2.resize(np_img, (w//8, h//8), interpolation=cv2.INTER_LINEAR),
-            "stage_2": cv2.resize(np_img, (w//4, h//4), interpolation=cv2.INTER_LINEAR),
-            "stage_1": cv2.resize(np_img, (w//2, h//2), interpolation=cv2.INTER_LINEAR),
-            "stage_0": np_img
-        }
-        return np_img_ms
-
-    
+        self.metas: List[Tuple[str, int, List[int]]] = []
+        for scan in scans:
+            pair_data = read_pair_file(os.path.join(self.datapath, self.split, scan, 'pair.txt'))
+            self.metas += [(scan, ref, src) for ref, src in pair_data]
 
     def __len__(self):
         return len(self.metas)
 
     def __getitem__(self, idx):
         
-        scan, _, ref_view, src_views = self.metas[idx]
+        scan, ref_view, src_views = self.metas[idx]
         # use only the reference view and first nviews-1 source views
         view_ids = [ref_view] + src_views[:self.n_views-1]
         img_w, img_h = self.image_sizes[scan]
@@ -117,71 +68,58 @@ class MVSDataset(Dataset):
             img_filename = os.path.join(self.datapath, self.split, scan, f'images/{vid:08d}.jpg')
             proj_mat_filename = os.path.join(self.datapath, self.split, scan, f'cams_1/{vid:08d}_cam.txt')
             
-            imgs = self.read_img(img_filename,self.img_wh[1], self.img_wh[0])
-            imgs_0.append(imgs['stage_0'])
-            imgs_1.append(imgs['stage_1'])
-            imgs_2.append(imgs['stage_2'])
-            imgs_3.append(imgs['stage_3'])
+            image, _, _ = read_image(img_filename, max(self.img_wh))
+            imgs_0.append(image)
+            imgs_1.append(cv2.resize(image, (self.img_wh[0]//2, self.img_wh[1]//2), interpolation=cv2.INTER_LINEAR))
+            imgs_2.append(cv2.resize(image, (self.img_wh[0]//4, self.img_wh[1]//4), interpolation=cv2.INTER_LINEAR))
+            imgs_3.append(cv2.resize(image, (self.img_wh[0]//8, self.img_wh[1]//8), interpolation=cv2.INTER_LINEAR))
 
-            intrinsics, extrinsics, depth_min_, depth_max_ = self.read_cam_file(proj_mat_filename)
+            intrinsics, extrinsics, depth_params = read_cam_file(proj_mat_filename)
             intrinsics[0] *= self.img_wh[0]/img_w
             intrinsics[1] *= self.img_wh[1]/img_h
-            
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 0.125
+            intrinsics[:2, :] *= 0.125
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_3.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_2.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_1.append(proj_mat)
 
             proj_mat = extrinsics.copy()
-            intrinsics[:2,:] *= 2
+            intrinsics[:2, :] *= 2
             proj_mat[:3, :4] = np.matmul(intrinsics, proj_mat[:3, :4])
             proj_matrices_0.append(proj_mat)
 
-
             if i == 0:  # reference view
-                depth_min =  depth_min_
-                depth_max = depth_max_
-
-                
-            
+                depth_min = depth_params[0]
+                depth_max = depth_params[1]
 
         # imgs: N*3*H0*W0, N is number of images
-        imgs_0 = np.stack(imgs_0).transpose([0, 3, 1, 2])
-        imgs_1 = np.stack(imgs_1).transpose([0, 3, 1, 2])
-        imgs_2 = np.stack(imgs_2).transpose([0, 3, 1, 2])
-        imgs_3 = np.stack(imgs_3).transpose([0, 3, 1, 2])
-        imgs = {}
-        imgs['stage_0'] = imgs_0
-        imgs['stage_1'] = imgs_1
-        imgs['stage_2'] = imgs_2
-        imgs['stage_3'] = imgs_3
+        imgs = {
+            'stage_0': np.stack(imgs_0).transpose([0, 3, 1, 2]),
+            'stage_1': np.stack(imgs_1).transpose([0, 3, 1, 2]),
+            'stage_2': np.stack(imgs_2).transpose([0, 3, 1, 2]),
+            'stage_3': np.stack(imgs_3).transpose([0, 3, 1, 2])
+        }
         # proj_matrices: N*4*4
-        proj_matrices_0 = np.stack(proj_matrices_0)
-        proj_matrices_1 = np.stack(proj_matrices_1)
-        proj_matrices_2 = np.stack(proj_matrices_2)
-        proj_matrices_3 = np.stack(proj_matrices_3)
-        proj={}
-        proj['stage_3']=proj_matrices_3
-        proj['stage_2']=proj_matrices_2
-        proj['stage_1']=proj_matrices_1
-        proj['stage_0']=proj_matrices_0
-        
-
+        proj = {
+            'stage_3': np.stack(proj_matrices_3),
+            'stage_2': np.stack(proj_matrices_2),
+            'stage_1': np.stack(proj_matrices_1),
+            'stage_0': np.stack(proj_matrices_0)
+        }
 
         return {"imgs": imgs,                   # N*3*H0*W0
-                "proj_matrices": proj, # N*4*4
+                "proj_matrices": proj,          # N*4*4
                 "depth_min": depth_min,         # scalar
-                "depth_max": depth_max,
+                "depth_max": depth_max,         # scalar
                 "filename": scan + '/{}/' + '{:0>8}'.format(view_ids[0]) + "{}"
                 }  

--- a/eval.py
+++ b/eval.py
@@ -1,23 +1,18 @@
 import argparse
 import os
-import torch
 import torch.nn as nn
 import torch.nn.parallel
 import torch.backends.cudnn as cudnn
-import torch.optim as optim
 from torch.utils.data import DataLoader
-from torch.autograd import Variable
-import torch.nn.functional as F
 import numpy as np
 import time
 from datasets import find_dataset_def
 from models import *
 from utils import *
 import sys
-from datasets.data_io import read_pfm, save_pfm
+from datasets.data_io import read_cam_file, read_pair_file, read_image, read_map, save_image, save_map
 import cv2
 from plyfile import PlyData, PlyElement
-from PIL import Image
 from typing import Tuple
 
 cudnn.benchmark = True
@@ -37,21 +32,23 @@ parser.add_argument('--loadckpt', default=None, help='load a specific checkpoint
 parser.add_argument('--outdir', default='./outputs', help='output dir')
 parser.add_argument('--display', action='store_true', help='display depth images and masks')
 
-parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1,2,2],
-        help='num of iteration of patchmatch on stages 1,2,3')
-parser.add_argument('--patchmatch_num_sample', nargs='+', type=int, default=[8,8,16],
-        help='num of generated samples in local perturbation on stages 1,2,3')
+parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1, 2, 2],
+                    help='num of iteration of patchmatch on stages 1,2,3')
+parser.add_argument('--patchmatch_num_sample', nargs='+', type=int, default=[8, 8, 16],
+                    help='num of generated samples in local perturbation on stages 1,2,3')
 parser.add_argument('--patchmatch_interval_scale', nargs='+', type=float, default=[0.005, 0.0125, 0.025],
-        help='normalized interval in inverse depth range to generate samples in local perturbation')
-parser.add_argument('--patchmatch_range', nargs='+', type=int, default=[6,4,2],
-        help='fixed offset of sampling points for propogation of patchmatch on stages 1,2,3')
-parser.add_argument('--propagate_neighbors', nargs='+', type=int, default=[0,8,16],
-        help='num of neighbors for adaptive propagation on stages 1,2,3')
-parser.add_argument('--evaluate_neighbors', nargs='+', type=int, default=[9,9,9],
-        help='num of neighbors for adaptive matching cost aggregation of adaptive evaluation on stages 1,2,3')
+                    help='normalized interval in inverse depth range to generate samples in local perturbation')
+parser.add_argument('--patchmatch_range', nargs='+', type=int, default=[6, 4, 2],
+                    help='fixed offset of sampling points for propogation of patchmatch on stages 1,2,3')
+parser.add_argument('--propagate_neighbors', nargs='+', type=int, default=[0, 8, 16],
+                    help='num of neighbors for adaptive propagation on stages 1,2,3')
+parser.add_argument('--evaluate_neighbors', nargs='+', type=int, default=[9, 9, 9],
+                    help='num of neighbors for adaptive matching cost aggregation of adaptive evaluation on stages 1,2,3')
 
-parser.add_argument('--geo_pixel_thres', type=float, default=1, help='pixel threshold for geometric consistency filtering')
-parser.add_argument('--geo_depth_thres', type=float, default=0.01, help='depth threshold for geometric consistency filtering')
+parser.add_argument('--geo_pixel_thres', type=float, default=1,
+                    help='pixel threshold for geometric consistency filtering')
+parser.add_argument('--geo_depth_thres', type=float, default=0.01,
+                    help='depth threshold for geometric consistency filtering')
 parser.add_argument('--photo_thres', type=float, default=0.8, help='threshold for photometric consistency filtering')
 
 # parse arguments and check
@@ -60,65 +57,23 @@ print("argv:", sys.argv[1:])
 print_args(args)
 
 
-# read intrinsics and extrinsics
-def read_camera_parameters(filename):
-    with open(filename) as f:
-        lines = f.readlines()
-        lines = [line.rstrip() for line in lines]
-    # extrinsics: line [1,5), 4x4 matrix
-    extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ').reshape((4, 4))
-    # intrinsics: line [7-10), 3x3 matrix
-    intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ').reshape((3, 3))
-
-    return intrinsics, extrinsics
-
-
-# read an image
-def read_img(filename, img_wh):
-    img = Image.open(filename)
-    # scale 0~255 to 0~1
-    np_img = np.array(img, dtype=np.float32) / 255.
-    np_img = cv2.resize(np_img, img_wh, interpolation=cv2.INTER_LINEAR)
-    return np_img
-
-
-# save a binary mask
-def save_mask(filename, mask):
-    assert mask.dtype == np.bool
-    mask = mask.astype(np.uint8) * 255
-    Image.fromarray(mask).save(filename)
-
-def save_depth_img(filename, depth):
-    # assert mask.dtype == np.bool
-    depth = depth.astype(np.float32) * 255
-    Image.fromarray(depth).save(filename)
-
-
-def read_pair_file(filename):
-    data = []
-    with open(filename) as f:
-        num_viewpoint = int(f.readline())
-        # 49 viewpoints
-        for view_idx in range(num_viewpoint):
-            ref_view = int(f.readline().rstrip())
-            src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-            data.append((ref_view, src_views))
-    return data
-
-
 # run MVS model to save depth maps
 def save_depth():
     # dataset, dataloader
-    MVSDataset = find_dataset_def(args.dataset)
-    test_dataset = MVSDataset(args.testpath, args.testlist, "test", args.n_views)
-    TestImgLoader = DataLoader(test_dataset, args.batch_size, shuffle=False, num_workers=4, drop_last=False)
+    mvs_dataset = find_dataset_def(args.dataset)
+    test_dataset = mvs_dataset(args.testpath, args.testlist, "test", args.n_views)
+    image_loader = DataLoader(test_dataset, args.batch_size, shuffle=False, num_workers=4, drop_last=False)
 
     # model
-    model = PatchmatchNet(patchmatch_interval_scale=args.patchmatch_interval_scale,
-                propagation_range = args.patchmatch_range, patchmatch_iteration=args.patchmatch_iteration,
-                patchmatch_num_sample = args.patchmatch_num_sample,
-                propagate_neighbors=args.propagate_neighbors, evaluate_neighbors=args.evaluate_neighbors)
-    model = nn.DataParallel(model)
+    model = PatchmatchNet(
+        patchmatch_interval_scale=args.patchmatch_interval_scale,
+        propagation_range=args.patchmatch_range,
+        patchmatch_iteration=args.patchmatch_iteration,
+        patchmatch_num_sample=args.patchmatch_num_sample,
+        propagate_neighbors=args.propagate_neighbors,
+        evaluate_neighbors=args.evaluate_neighbors
+    )
+    # model = nn.DataParallel(model)
     model.cuda()
 
     # load checkpoint file specified by args.loadckpt
@@ -129,7 +84,7 @@ def save_depth():
     model.eval()
 
     with torch.no_grad():
-        for batch_idx, sample in enumerate(TestImgLoader):
+        for batch_idx, sample in enumerate(image_loader):
             start_time = time.time()
             sample_cuda = tocuda(sample)
             refined_depth, confidence, _ = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
@@ -138,7 +93,7 @@ def save_depth():
             confidence = tensor2numpy(confidence)
 
             del sample_cuda
-            print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(TestImgLoader), time.time() - start_time))
+            print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(image_loader), time.time() - start_time))
             filenames = sample["filename"]
 
             # save depth maps and confidence maps
@@ -149,10 +104,9 @@ def save_depth():
                 os.makedirs(confidence_filename.rsplit('/', 1)[0], exist_ok=True)
                 # save depth maps
                 depth_est = np.squeeze(depth_est, 0)
-                save_pfm(depth_filename, depth_est)
+                save_map(depth_filename, depth_est)
                 # save confidence maps
-                save_pfm(confidence_filename, photometric_confidence)
-
+                save_map(confidence_filename, photometric_confidence)
 
 
 # project the reference point cloud into the source view, then project back
@@ -183,7 +137,7 @@ def reproject_with_depth(
             y_src: y coordinates of points in the source view, of shape (H, W)
     """
     width, height = depth_ref.shape[1], depth_ref.shape[0]
-    ## step1. project reference pixels to the source view
+    # step1. project reference pixels to the source view
     # reference view x, y
     x_ref, y_ref = np.meshgrid(np.arange(0, width), np.arange(0, height))
     x_ref, y_ref = x_ref.reshape([-1]), y_ref.reshape([-1])
@@ -194,10 +148,10 @@ def reproject_with_depth(
     xyz_src = np.matmul(np.matmul(extrinsics_src, np.linalg.inv(extrinsics_ref)),
                         np.vstack((xyz_ref, np.ones_like(x_ref))))[:3]
     # source view x, y
-    K_xyz_src = np.matmul(intrinsics_src, xyz_src)
-    xy_src = K_xyz_src[:2] / K_xyz_src[2:3]
+    k_xyz_src = np.matmul(intrinsics_src, xyz_src)
+    xy_src = k_xyz_src[:2] / k_xyz_src[2:3]
 
-    ## step2. reproject the source view points with source view depth estimation
+    # step2. reproject the source view points with source view depth estimation
     # find the depth estimation of the source view
     x_src = xy_src[0].reshape([height, width]).astype(np.float32)
     y_src = xy_src[1].reshape([height, width]).astype(np.float32)
@@ -213,8 +167,8 @@ def reproject_with_depth(
                                 np.vstack((xyz_src, np.ones_like(x_ref))))[:3]
     # source view x, y, depth
     depth_reprojected = xyz_reprojected[2].reshape([height, width]).astype(np.float32)
-    K_xyz_reprojected = np.matmul(intrinsics_ref, xyz_reprojected)
-    xy_reprojected = K_xyz_reprojected[:2] / K_xyz_reprojected[2:3]
+    k_xyz_reprojected = np.matmul(intrinsics_ref, xyz_reprojected)
+    xy_reprojected = k_xyz_reprojected[:2] / k_xyz_reprojected[2:3]
     x_reprojected = xy_reprojected[0].reshape([height, width]).astype(np.float32)
     y_reprojected = xy_reprojected[1].reshape([height, width]).astype(np.float32)
 
@@ -252,8 +206,8 @@ def check_geometric_consistency(
     """
     width, height = depth_ref.shape[1], depth_ref.shape[0]
     x_ref, y_ref = np.meshgrid(np.arange(0, width), np.arange(0, height))
-    depth_reprojected, x2d_reprojected, y2d_reprojected, x2d_src, y2d_src = reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref,
-                                                     depth_src, intrinsics_src, extrinsics_src)
+    depth_reprojected, x2d_reprojected, y2d_reprojected, x2d_src, y2d_src = reproject_with_depth(
+        depth_ref, intrinsics_ref, extrinsics_ref, depth_src, intrinsics_src, extrinsics_src)
     # print(depth_ref.shape)
     # print(depth_reprojected.shape)
     # check |p_reproj-p_1| < 1
@@ -278,52 +232,44 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
     vertex_colors = []
 
     pair_data = read_pair_file(pair_file)
-    nviews = len(pair_data)
     original_w = 1600
     original_h = 1200
-
 
     # for each reference view and the corresponding source views
     for ref_view, src_views in pair_data:
         # load the camera parameters
-        ref_intrinsics, ref_extrinsics = read_camera_parameters(
+        ref_intrinsics, ref_extrinsics, _ = read_cam_file(
             os.path.join(scan_folder, 'cams_1/{:0>8}_cam.txt'.format(ref_view)))
         ref_intrinsics[0] *= img_wh[0]/original_w
         ref_intrinsics[1] *= img_wh[1]/original_h
         # load the reference image
-        ref_img = read_img(os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(ref_view)), img_wh)
+        ref_img, _, _ = read_image(os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(ref_view)), max(img_wh))
         # load the estimated depth of the reference view
-        ref_depth_est = read_pfm(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(ref_view)))[0]
+        ref_depth_est = read_map(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(ref_view)))
         ref_depth_est = np.squeeze(ref_depth_est, 2)
         # load the photometric mask of the reference view
-        confidence = read_pfm(os.path.join(out_folder, 'confidence/{:0>8}.pfm'.format(ref_view)))[0]
+        confidence = read_map(os.path.join(out_folder, 'confidence/{:0>8}.pfm'.format(ref_view)))
 
         photo_mask = confidence > photo_thres
         photo_mask = np.squeeze(photo_mask, 2)
 
-
         all_srcview_depth_ests = []
-
-
         # compute the geometric mask
-        geo_mask_sum = 0
+        geo_mask_sum = np.zeros_like(ref_depth_est, dtype=np.int32)
         for src_view in src_views:
             # camera parameters of the source view
-            src_intrinsics, src_extrinsics = read_camera_parameters(
+            src_intrinsics, src_extrinsics, _ = read_cam_file(
                 os.path.join(scan_folder, 'cams_1/{:0>8}_cam.txt'.format(src_view)))
             src_intrinsics[0] *= img_wh[0]/original_w
             src_intrinsics[1] *= img_wh[1]/original_h
             # the estimated depth of the source view
-            src_depth_est = read_pfm(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(src_view)))[0]
+            src_depth_est = read_map(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(src_view)))
 
-
-            geo_mask, depth_reprojected, x2d_src, y2d_src = check_geometric_consistency(ref_depth_est, ref_intrinsics, ref_extrinsics,
-                                                                      src_depth_est,
-                                                                      src_intrinsics, src_extrinsics,
-                                                                      geo_pixel_thres, geo_depth_thres)
+            geo_mask, depth_reprojected, _, _ = check_geometric_consistency(
+                ref_depth_est, ref_intrinsics, ref_extrinsics, src_depth_est, src_intrinsics, src_extrinsics,
+                geo_pixel_thres, geo_depth_thres)
             geo_mask_sum += geo_mask.astype(np.int32)
             all_srcview_depth_ests.append(depth_reprojected)
-
 
         depth_est_averaged = (sum(all_srcview_depth_ests) + ref_depth_est) / (geo_mask_sum + 1)
         # at least 3 source views matched
@@ -331,22 +277,16 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
         geo_mask = geo_mask_sum >= 3
         final_mask = np.logical_and(photo_mask, geo_mask)
 
-
-
-
         os.makedirs(os.path.join(out_folder, "mask"), exist_ok=True)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_photo.png".format(ref_view)), photo_mask)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_geo.png".format(ref_view)), geo_mask)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_final.png".format(ref_view)), final_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_photo.png".format(ref_view)), photo_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_geo.png".format(ref_view)), geo_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_final.png".format(ref_view)), final_mask)
         os.makedirs(os.path.join(out_folder, "depth_img"), exist_ok=True)
 
-
-
-        print("processing {}, ref-view{:0>2}, geo_mask:{:3f} photo_mask:{:3f} final_mask: {:3f}".format(scan_folder, ref_view,
-                                                                geo_mask.mean(), photo_mask.mean(), final_mask.mean()))
+        print("processing {}, ref-view{:0>2}, geo_mask:{:3f} photo_mask:{:3f} final_mask: {:3f}".format(
+            scan_folder, ref_view, geo_mask.mean(), photo_mask.mean(), final_mask.mean()))
 
         if args.display:
-            import cv2
             cv2.imshow('ref_img', ref_img[:, :, ::-1])
             cv2.imshow('ref_depth', ref_depth_est / 800)
             cv2.imshow('ref_depth * photo_mask', ref_depth_est * photo_mask.astype(np.float32) / 800)
@@ -362,13 +302,10 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
         x, y, depth = x[valid_points], y[valid_points], depth_est_averaged[valid_points]
 
         color = ref_img[valid_points]
-        xyz_ref = np.matmul(    np.linalg.inv(ref_intrinsics),
-                            np.vstack((x, y, np.ones_like(x))) * depth)
-        xyz_world = np.matmul(np.linalg.inv(ref_extrinsics),
-                              np.vstack((xyz_ref, np.ones_like(x))))[:3]
+        xyz_ref = np.matmul(np.linalg.inv(ref_intrinsics), np.vstack((x, y, np.ones_like(x))) * depth)
+        xyz_world = np.matmul(np.linalg.inv(ref_extrinsics), np.vstack((xyz_ref, np.ones_like(x))))[:3]
         vertexs.append(xyz_world.transpose((1, 0)))
         vertex_colors.append((color * 255).astype(np.uint8))
-
 
     vertexs = np.concatenate(vertexs, axis=0)
     vertex_colors = np.concatenate(vertex_colors, axis=0)
@@ -389,12 +326,11 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
 if __name__ == '__main__':
     # step1. save all the depth maps and the masks in outputs directory
     save_depth()
-    img_wh=(1600, 1200)
+    img_wh = (1600, 1200)
 
     with open(args.testlist) as f:
         scans = f.readlines()
         scans = [line.rstrip() for line in scans]
-
 
     for scan in scans:
         scan_id = int(scan[4:])
@@ -402,4 +338,4 @@ if __name__ == '__main__':
         out_folder = os.path.join(args.outdir, scan)
         # step2. filter saved depth maps with geometric constraints
         filter_depth(scan_folder, out_folder, os.path.join(args.outdir, 'patchmatchnet{:0>3}_l3.ply'.format(scan_id)),
-                    args.geo_pixel_thres, args.geo_depth_thres, args.photo_thres, img_wh)
+                     args.geo_pixel_thres, args.geo_depth_thres, args.photo_thres, img_wh)

--- a/eval_custom.py
+++ b/eval_custom.py
@@ -1,25 +1,17 @@
 import argparse
 import os
-import torch
 import torch.nn as nn
 import torch.nn.parallel
 import torch.backends.cudnn as cudnn
-import torch.optim as optim
 from torch.utils.data import DataLoader
-from torch.autograd import Variable
-import torch.nn.functional as F
-import numpy as np
 import time
 from datasets import find_dataset_def
 from models import *
 from utils import *
 import sys
-from datasets.data_io import read_pfm, save_pfm
+from datasets.data_io import read_cam_file, read_pair_file, read_image, read_map, save_image, save_map
 import cv2
 from plyfile import PlyData, PlyElement
-from PIL import Image
-import math
-# import scipy.signal as signal
 
 cudnn.benchmark = True
 
@@ -39,21 +31,23 @@ parser.add_argument('--loadckpt', default=None, help='load a specific checkpoint
 parser.add_argument('--outdir', default='./outputs', help='output dir')
 parser.add_argument('--display', action='store_true', help='display depth images and masks')
 
-parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1,2,2], 
-        help='num of iteration of patchmatch on stages 1,2,3')
-parser.add_argument('--patchmatch_num_sample', nargs='+', type=int, default=[8,8,16], 
-        help='num of generated samples in local perturbation on stages 1,2,3')
+parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1, 2, 2],
+                    help='num of iteration of patchmatch on stages 1,2,3')
+parser.add_argument('--patchmatch_num_sample', nargs='+', type=int, default=[8, 8, 16],
+                    help='num of generated samples in local perturbation on stages 1,2,3')
 parser.add_argument('--patchmatch_interval_scale', nargs='+', type=float, default=[0.005, 0.0125, 0.025], 
-        help='normalized interval in inverse depth range to generate samples in local perturbation')
-parser.add_argument('--patchmatch_range', nargs='+', type=int, default=[6,4,2], 
-        help='fixed offset of sampling points for propogation of patchmatch on stages 1,2,3')
-parser.add_argument('--propagate_neighbors', nargs='+', type=int, default=[0,8,16], 
-        help='num of neighbors for adaptive propagation on stages 1,2,3')
-parser.add_argument('--evaluate_neighbors', nargs='+', type=int, default=[9,9,9], 
-        help='num of neighbors for adaptive matching cost aggregation of adaptive evaluation on stages 1,2,3')
+                    help='normalized interval in inverse depth range to generate samples in local perturbation')
+parser.add_argument('--patchmatch_range', nargs='+', type=int, default=[6, 4, 2],
+                    help='fixed offset of sampling points for propogation of patchmatch on stages 1,2,3')
+parser.add_argument('--propagate_neighbors', nargs='+', type=int, default=[0, 8, 16],
+                    help='num of neighbors for adaptive propagation on stages 1,2,3')
+parser.add_argument('--evaluate_neighbors', nargs='+', type=int, default=[9, 9, 9],
+                    help='num of neighbors for adaptive matching cost aggregation of adaptive evaluation on stages 1,2,3')
 
-parser.add_argument('--geo_pixel_thres', type=float, default=1, help='pixel threshold for geometric consistency filtering')
-parser.add_argument('--geo_depth_thres', type=float, default=0.01, help='depth threshold for geometric consistency filtering')
+parser.add_argument('--geo_pixel_thres', type=float, default=1,
+                    help='pixel threshold for geometric consistency filtering')
+parser.add_argument('--geo_depth_thres', type=float, default=0.01,
+                    help='depth threshold for geometric consistency filtering')
 parser.add_argument('--photo_thres', type=float, default=0.8, help='threshold for photometric consistency filtering')
 
 # parse arguments and check
@@ -62,70 +56,22 @@ print("argv:", sys.argv[1:])
 print_args(args)
 
 
-# read an image
-def read_img(filename, img_wh):
-    img = Image.open(filename)
-    # scale 0~255 to 0~1
-    np_img = np.array(img, dtype=np.float32) / 255.
-    original_h, original_w, _ = np_img.shape
-    np_img = cv2.resize(np_img, img_wh, interpolation=cv2.INTER_LINEAR)
-    
-    return np_img, original_h, original_w
-
-
-def read_cam_file(filename):
-    with open(filename) as f:
-        lines = [line.rstrip() for line in f.readlines()]
-    # extrinsics: line [1,5), 4x4 matrix
-    extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ')
-    extrinsics = extrinsics.reshape((4, 4))
-    # intrinsics: line [7-10), 3x3 matrix
-    intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ')
-    intrinsics = intrinsics.reshape((3, 3))
-    
-    depth_min = float(lines[11].split()[0])
-    depth_max = float(lines[11].split()[1])
-
-    return intrinsics, extrinsics, depth_min, depth_max
-
-# save a binary mask
-def save_mask(filename, mask):
-    assert mask.dtype == np.bool
-    mask = mask.astype(np.uint8) * 255
-    Image.fromarray(mask).save(filename)
-
-def save_depth_img(filename, depth):
-    # assert mask.dtype == np.bool
-    depth = depth * 255
-    depth = depth.astype(np.uint8)
-    Image.fromarray(depth).save(filename)
-
-
-def read_pair_file(filename):
-    data = []
-    with open(filename) as f:
-        num_viewpoint = int(f.readline())
-        # 49 viewpoints
-        for view_idx in range(num_viewpoint):
-            ref_view = int(f.readline().rstrip())
-            src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-            if len(src_views) != 0:
-                data.append((ref_view, src_views))
-    return data
-
-
 # run MVS model to save depth maps
 def save_depth():
     # dataset, dataloader
-    MVSDataset = find_dataset_def(args.dataset)
-    test_dataset = MVSDataset(args.testpath, args.n_views)
-    TestImgLoader = DataLoader(test_dataset, args.batch_size, shuffle=False, num_workers=4, drop_last=False)
+    mvs_dataset = find_dataset_def(args.dataset)
+    test_dataset = mvs_dataset(args.testpath, args.n_views)
+    image_loader = DataLoader(test_dataset, args.batch_size, shuffle=False, num_workers=4, drop_last=False)
 
     # model
-    model = PatchmatchNet(patchmatch_interval_scale=args.patchmatch_interval_scale,
-                propagation_range = args.patchmatch_range, patchmatch_iteration=args.patchmatch_iteration, 
-                patchmatch_num_sample = args.patchmatch_num_sample, 
-                propagate_neighbors=args.propagate_neighbors, evaluate_neighbors=args.evaluate_neighbors)
+    model = PatchmatchNet(
+        patchmatch_interval_scale=args.patchmatch_interval_scale,
+        propagation_range=args.patchmatch_range,
+        patchmatch_iteration=args.patchmatch_iteration,
+        patchmatch_num_sample=args.patchmatch_num_sample,
+        propagate_neighbors=args.propagate_neighbors,
+        evaluate_neighbors=args.evaluate_neighbors
+    )
     model = nn.DataParallel(model)
     model.cuda()
 
@@ -136,7 +82,7 @@ def save_depth():
     model.eval()
     
     with torch.no_grad():
-        for batch_idx, sample in enumerate(TestImgLoader):
+        for batch_idx, sample in enumerate(image_loader):
             start_time = time.time()
             sample_cuda = tocuda(sample)
             refined_depth, confidence, _ = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
@@ -145,7 +91,7 @@ def save_depth():
             confidence = tensor2numpy(confidence)
 
             del sample_cuda
-            print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(TestImgLoader), time.time() - start_time))
+            print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(image_loader), time.time() - start_time))
             filenames = sample["filename"]
 
             # save depth maps and confidence maps
@@ -156,16 +102,15 @@ def save_depth():
                 os.makedirs(confidence_filename.rsplit('/', 1)[0], exist_ok=True)
                 # save depth maps
                 depth_est = np.squeeze(depth_est, 0)
-                save_pfm(depth_filename, depth_est)
+                save_map(depth_filename, depth_est)
                 # save confidence maps
-                save_pfm(confidence_filename, photometric_confidence)
+                save_map(confidence_filename, photometric_confidence)
                 
-
 
 # project the reference point cloud into the source view, then project back
 def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, intrinsics_src, extrinsics_src):
     width, height = depth_ref.shape[1], depth_ref.shape[0]
-    ## step1. project reference pixels to the source view
+    # step1. project reference pixels to the source view
     # reference view x, y
     x_ref, y_ref = np.meshgrid(np.arange(0, width), np.arange(0, height))
     x_ref, y_ref = x_ref.reshape([-1]), y_ref.reshape([-1])
@@ -176,10 +121,10 @@ def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, i
     xyz_src = np.matmul(np.matmul(extrinsics_src, np.linalg.inv(extrinsics_ref)),
                         np.vstack((xyz_ref, np.ones_like(x_ref))))[:3]
     # source view x, y
-    K_xyz_src = np.matmul(intrinsics_src, xyz_src)
-    xy_src = K_xyz_src[:2] / K_xyz_src[2:3]
+    k_xyz_src = np.matmul(intrinsics_src, xyz_src)
+    xy_src = k_xyz_src[:2] / k_xyz_src[2:3]
 
-    ## step2. reproject the source view points with source view depth estimation
+    # step2. reproject the source view points with source view depth estimation
     # find the depth estimation of the source view
     x_src = xy_src[0].reshape([height, width]).astype(np.float32)
     y_src = xy_src[1].reshape([height, width]).astype(np.float32)
@@ -195,8 +140,8 @@ def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, i
                                 np.vstack((xyz_src, np.ones_like(x_ref))))[:3]
     # source view x, y, depth
     depth_reprojected = xyz_reprojected[2].reshape([height, width]).astype(np.float32)
-    K_xyz_reprojected = np.matmul(intrinsics_ref, xyz_reprojected)
-    xy_reprojected = K_xyz_reprojected[:2] / K_xyz_reprojected[2:3]
+    k_xyz_reprojected = np.matmul(intrinsics_ref, xyz_reprojected)
+    xy_reprojected = k_xyz_reprojected[:2] / k_xyz_reprojected[2:3]
     x_reprojected = xy_reprojected[0].reshape([height, width]).astype(np.float32)
     y_reprojected = xy_reprojected[1].reshape([height, width]).astype(np.float32)
 
@@ -207,8 +152,8 @@ def check_geometric_consistency(depth_ref, intrinsics_ref, extrinsics_ref, depth
                                 geo_pixel_thres, geo_depth_thres):
     width, height = depth_ref.shape[1], depth_ref.shape[0]
     x_ref, y_ref = np.meshgrid(np.arange(0, width), np.arange(0, height))
-    depth_reprojected, x2d_reprojected, y2d_reprojected, x2d_src, y2d_src = reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref,
-                                                     depth_src, intrinsics_src, extrinsics_src)
+    depth_reprojected, x2d_reprojected, y2d_reprojected, x2d_src, y2d_src = reproject_with_depth(
+        depth_ref, intrinsics_ref, extrinsics_ref, depth_src, intrinsics_src, extrinsics_src)
     # print(depth_ref.shape)
     # print(depth_reprojected.shape)
     # check |p_reproj-p_1| < 1
@@ -225,7 +170,8 @@ def check_geometric_consistency(depth_ref, intrinsics_ref, extrinsics_ref, depth
     return mask, depth_reprojected, x2d_src, y2d_src
 
 
-def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_depth_thres, photo_thres, img_wh, geo_mask_thres):
+def filter_depth(
+        scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_depth_thres, photo_thres, img_wh, geo_mask_thres):
     # the pair file
     pair_file = os.path.join(scan_folder, "pair.txt")
     # for the final point cloud
@@ -233,71 +179,65 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
     vertex_colors = []
 
     pair_data = read_pair_file(pair_file)
-    nviews = len(pair_data)
-    
 
     # for each reference view and the corresponding source views
     for ref_view, src_views in pair_data:
         
         # load the reference image
-        ref_img, original_h, original_w = read_img(os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(ref_view)),img_wh)
-        ref_intrinsics, ref_extrinsics = read_cam_file(
+        ref_img, original_h, original_w = read_image(
+            os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(ref_view)), max(img_wh))
+        ref_intrinsics, ref_extrinsics, _ = read_cam_file(
             os.path.join(scan_folder, 'cams/{:0>8}_cam.txt'.format(ref_view)))[0:2]
         ref_intrinsics[0] *= img_wh[0]/original_w
         ref_intrinsics[1] *= img_wh[1]/original_h
         
         # load the estimated depth of the reference view
-        ref_depth_est = read_pfm(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(ref_view)))[0]
+        ref_depth_est = read_map(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(ref_view)))
         ref_depth_est = np.squeeze(ref_depth_est, 2)
         # load the photometric mask of the reference view
-        confidence = read_pfm(os.path.join(out_folder, 'confidence/{:0>8}.pfm'.format(ref_view)))[0]
+        confidence = read_map(os.path.join(out_folder, 'confidence/{:0>8}.pfm'.format(ref_view)))
         
         photo_mask = confidence > photo_thres
         photo_mask = np.squeeze(photo_mask, 2)
-        
 
         all_srcview_depth_ests = []
-        
         # compute the geometric mask
         geo_mask_sum = 0
         for src_view in src_views:
             # camera parameters of the source view
-            _, original_h, original_w = read_img(os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(src_view)), img_wh)
-            src_intrinsics, src_extrinsics = read_cam_file(
+            _, original_h, original_w = read_image(
+                os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(src_view)), max(img_wh))
+            src_intrinsics, src_extrinsics, _ = read_cam_file(
                 os.path.join(scan_folder, 'cams/{:0>8}_cam.txt'.format(src_view)))[0:2]
             src_intrinsics[0] *= img_wh[0]/original_w
             src_intrinsics[1] *= img_wh[1]/original_h
             
             # the estimated depth of the source view
-            src_depth_est = read_pfm(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(src_view)))[0]
+            src_depth_est = read_map(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(src_view)))
 
-            geo_mask, depth_reprojected, x2d_src, y2d_src = check_geometric_consistency(ref_depth_est, ref_intrinsics, ref_extrinsics,
-                                                                      src_depth_est,
-                                                                      src_intrinsics, src_extrinsics,
-                                                                      geo_pixel_thres, geo_depth_thres)
+            geo_mask, depth_reprojected, _, _ = check_geometric_consistency(
+                ref_depth_est, ref_intrinsics, ref_extrinsics, src_depth_est, src_intrinsics, src_extrinsics,
+                geo_pixel_thres, geo_depth_thres)
             geo_mask_sum += geo_mask.astype(np.int32)
             all_srcview_depth_ests.append(depth_reprojected)
-            
 
         depth_est_averaged = (sum(all_srcview_depth_ests) + ref_depth_est) / (geo_mask_sum + 1)
-        
         geo_mask = geo_mask_sum >= geo_mask_thres
         final_mask = np.logical_and(photo_mask, geo_mask)
-        
+
         os.makedirs(os.path.join(out_folder, "mask"), exist_ok=True)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_photo.png".format(ref_view)), photo_mask)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_geo.png".format(ref_view)), geo_mask)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_final.png".format(ref_view)), final_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_photo.png".format(ref_view)), photo_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_geo.png".format(ref_view)), geo_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_final.png".format(ref_view)), final_mask)
         
-        print("processing {}, ref-view{:0>2}, geo_mask:{:3f} photo_mask:{:3f} final_mask: {:3f}".format(scan_folder, ref_view,
-                                                                geo_mask.mean(), photo_mask.mean(), final_mask.mean()))
+        print("processing {}, ref-view{:0>2}, geo_mask:{:3f} photo_mask:{:3f} final_mask: {:3f}".format(
+            scan_folder, ref_view, geo_mask.mean(), photo_mask.mean(), final_mask.mean()))
 
         if args.display:
-            import cv2
             cv2.imshow('ref_img', ref_img[:, :, ::-1])
-            cv2.imshow('ref_depth', ref_depth_est )
+            cv2.imshow('ref_depth', ref_depth_est)
             cv2.imshow('ref_depth * photo_mask', ref_depth_est * photo_mask.astype(np.float32))
-            cv2.imshow('ref_depth * geo_mask', ref_depth_est * geo_mask.astype(np.float32) )
+            cv2.imshow('ref_depth * geo_mask', ref_depth_est * geo_mask.astype(np.float32))
             cv2.imshow('ref_depth * mask', ref_depth_est * final_mask.astype(np.float32))
             cv2.waitKey(1)
 
@@ -309,10 +249,8 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
         x, y, depth = x[valid_points], y[valid_points], depth_est_averaged[valid_points]
         
         color = ref_img[valid_points]
-        xyz_ref = np.matmul(    np.linalg.inv(ref_intrinsics),
-                            np.vstack((x, y, np.ones_like(x))) * depth)
-        xyz_world = np.matmul(np.linalg.inv(ref_extrinsics),
-                              np.vstack((xyz_ref, np.ones_like(x))))[:3]
+        xyz_ref = np.matmul(np.linalg.inv(ref_intrinsics), np.vstack((x, y, np.ones_like(x))) * depth)
+        xyz_world = np.matmul(np.linalg.inv(ref_extrinsics), np.vstack((xyz_ref, np.ones_like(x))))[:3]
         vertexs.append(xyz_world.transpose((1, 0)))
         vertex_colors.append((color * 255).astype(np.uint8))
 
@@ -336,13 +274,10 @@ if __name__ == '__main__':
     # step1. save all the depth maps and the masks in outputs directory
     save_depth()
     # the size of image input for PatchmatchNet, maybe downsampled
-    img_wh = (736,416)
+    img_wh = (736, 416)
     # number of source images need to be consistent with in geometric consistency filtering
     geo_mask_thres = 2
 
-        
     # step2. filter saved depth maps and reconstruct point cloud
-    filter_depth(args.testpath, args.outdir, os.path.join(args.outdir, 'custom.ply'), 
-                args.geo_pixel_thres, args.geo_depth_thres, args.photo_thres, img_wh, geo_mask_thres) 
-    
-
+    filter_depth(args.testpath, args.outdir, os.path.join(args.outdir, 'custom.ply'),  args.geo_pixel_thres,
+                 args.geo_depth_thres, args.photo_thres, img_wh, geo_mask_thres)

--- a/eval_eth.py
+++ b/eval_eth.py
@@ -1,25 +1,17 @@
 import argparse
 import os
-import torch
 import torch.nn as nn
 import torch.nn.parallel
 import torch.backends.cudnn as cudnn
-import torch.optim as optim
 from torch.utils.data import DataLoader
-from torch.autograd import Variable
-import torch.nn.functional as F
-import numpy as np
 import time
 from datasets import find_dataset_def
 from models import *
 from utils import *
 import sys
-from datasets.data_io import read_pfm, save_pfm
+from datasets.data_io import read_cam_file, read_pair_file, read_image, read_map, save_image, save_map
 import cv2
 from plyfile import PlyData, PlyElement
-from PIL import Image
-import math
-# import scipy.signal as signal
 
 cudnn.benchmark = True
 
@@ -39,21 +31,23 @@ parser.add_argument('--loadckpt', default=None, help='load a specific checkpoint
 parser.add_argument('--outdir', default='./outputs', help='output dir')
 parser.add_argument('--display', action='store_true', help='display depth images and masks')
 
-parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1,2,2], 
-        help='num of iteration of patchmatch on stages 1,2,3')
-parser.add_argument('--patchmatch_num_sample', nargs='+', type=int, default=[8,8,16], 
-        help='num of generated samples in local perturbation on stages 1,2,3')
+parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1, 2, 2],
+                    help='num of iteration of patchmatch on stages 1,2,3')
+parser.add_argument('--patchmatch_num_sample', nargs='+', type=int, default=[8, 8, 16],
+                    help='num of generated samples in local perturbation on stages 1,2,3')
 parser.add_argument('--patchmatch_interval_scale', nargs='+', type=float, default=[0.005, 0.0125, 0.025], 
-        help='normalized interval in inverse depth range to generate samples in local perturbation')
-parser.add_argument('--patchmatch_range', nargs='+', type=int, default=[6,4,2], 
-        help='fixed offset of sampling points for propogation of patchmatch on stages 1,2,3')
-parser.add_argument('--propagate_neighbors', nargs='+', type=int, default=[0,8,16], 
-        help='num of neighbors for adaptive propagation on stages 1,2,3')
-parser.add_argument('--evaluate_neighbors', nargs='+', type=int, default=[9,9,9], 
-        help='num of neighbors for adaptive matching cost aggregation of adaptive evaluation on stages 1,2,3')
+                    help='normalized interval in inverse depth range to generate samples in local perturbation')
+parser.add_argument('--patchmatch_range', nargs='+', type=int, default=[6, 4, 2],
+                    help='fixed offset of sampling points for propogation of patchmatch on stages 1,2,3')
+parser.add_argument('--propagate_neighbors', nargs='+', type=int, default=[0, 8, 16],
+                    help='num of neighbors for adaptive propagation on stages 1,2,3')
+parser.add_argument('--evaluate_neighbors', nargs='+', type=int, default=[9, 9, 9],
+                    help='num of neighbors for adaptive matching cost aggregation of adaptive evaluation on stages 1,2,3')
 
-parser.add_argument('--geo_pixel_thres', type=float, default=1, help='pixel threshold for geometric consistency filtering')
-parser.add_argument('--geo_depth_thres', type=float, default=0.01, help='depth threshold for geometric consistency filtering')
+parser.add_argument('--geo_pixel_thres', type=float, default=1,
+                    help='pixel threshold for geometric consistency filtering')
+parser.add_argument('--geo_depth_thres', type=float, default=0.01,
+                    help='depth threshold for geometric consistency filtering')
 parser.add_argument('--photo_thres', type=float, default=0.8, help='threshold for photometric consistency filtering')
 
 # parse arguments and check
@@ -62,70 +56,22 @@ print("argv:", sys.argv[1:])
 print_args(args)
 
 
-# read an image
-def read_img(filename, img_wh):
-    img = Image.open(filename)
-    # scale 0~255 to 0~1
-    np_img = np.array(img, dtype=np.float32) / 255.
-    original_h, original_w, _ = np_img.shape
-    np_img = cv2.resize(np_img, img_wh, interpolation=cv2.INTER_LINEAR)
-    
-    return np_img, original_h, original_w
-
-
-def read_cam_file(filename):
-    with open(filename) as f:
-        lines = [line.rstrip() for line in f.readlines()]
-    # extrinsics: line [1,5), 4x4 matrix
-    extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ')
-    extrinsics = extrinsics.reshape((4, 4))
-    # intrinsics: line [7-10), 3x3 matrix
-    intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ')
-    intrinsics = intrinsics.reshape((3, 3))
-    
-    depth_min = float(lines[11].split()[0])
-    depth_max = float(lines[11].split()[1])
-
-    return intrinsics, extrinsics, depth_min, depth_max
-
-# save a binary mask
-def save_mask(filename, mask):
-    assert mask.dtype == np.bool
-    mask = mask.astype(np.uint8) * 255
-    Image.fromarray(mask).save(filename)
-
-def save_depth_img(filename, depth):
-    # assert mask.dtype == np.bool
-    depth = depth * 255
-    depth = depth.astype(np.uint8)
-    Image.fromarray(depth).save(filename)
-
-
-def read_pair_file(filename):
-    data = []
-    with open(filename) as f:
-        num_viewpoint = int(f.readline())
-        # 49 viewpoints
-        for view_idx in range(num_viewpoint):
-            ref_view = int(f.readline().rstrip())
-            src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-            if len(src_views) != 0:
-                data.append((ref_view, src_views))
-    return data
-
-
 # run MVS model to save depth maps
 def save_depth():
     # dataset, dataloader
-    MVSDataset = find_dataset_def(args.dataset)
-    test_dataset = MVSDataset(args.testpath, args.split, args.n_views)
-    TestImgLoader = DataLoader(test_dataset, args.batch_size, shuffle=False, num_workers=4, drop_last=False)
+    mvs_dataset = find_dataset_def(args.dataset)
+    test_dataset = mvs_dataset(args.testpath, args.split, args.n_views)
+    image_loader = DataLoader(test_dataset, args.batch_size, shuffle=False, num_workers=4, drop_last=False)
 
     # model
-    model = PatchmatchNet(patchmatch_interval_scale=args.patchmatch_interval_scale,
-                propagation_range = args.patchmatch_range, patchmatch_iteration=args.patchmatch_iteration, 
-                patchmatch_num_sample = args.patchmatch_num_sample, 
-                propagate_neighbors=args.propagate_neighbors, evaluate_neighbors=args.evaluate_neighbors)
+    model = PatchmatchNet(
+        patchmatch_interval_scale=args.patchmatch_interval_scale,
+        propagation_range=args.patchmatch_range,
+        patchmatch_iteration=args.patchmatch_iteration,
+        patchmatch_num_sample=args.patchmatch_num_sample,
+        propagate_neighbors=args.propagate_neighbors,
+        evaluate_neighbors=args.evaluate_neighbors
+    )
     model = nn.DataParallel(model)
     model.cuda()
 
@@ -136,7 +82,7 @@ def save_depth():
     model.eval()
     
     with torch.no_grad():
-        for batch_idx, sample in enumerate(TestImgLoader):
+        for batch_idx, sample in enumerate(image_loader):
             start_time = time.time()
             sample_cuda = tocuda(sample)
             refined_depth, confidence, _ = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
@@ -145,7 +91,7 @@ def save_depth():
             confidence = tensor2numpy(confidence)
 
             del sample_cuda
-            print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(TestImgLoader), time.time() - start_time))
+            print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(image_loader), time.time() - start_time))
             filenames = sample["filename"]
 
             # save depth maps and confidence maps
@@ -156,16 +102,15 @@ def save_depth():
                 os.makedirs(confidence_filename.rsplit('/', 1)[0], exist_ok=True)
                 # save depth maps
                 depth_est = np.squeeze(depth_est, 0)
-                save_pfm(depth_filename, depth_est)
+                save_map(depth_filename, depth_est)
                 # save confidence maps
-                save_pfm(confidence_filename, photometric_confidence)
-                
+                save_map(confidence_filename, photometric_confidence)
 
 
 # project the reference point cloud into the source view, then project back
 def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, intrinsics_src, extrinsics_src):
     width, height = depth_ref.shape[1], depth_ref.shape[0]
-    ## step1. project reference pixels to the source view
+    # step1. project reference pixels to the source view
     # reference view x, y
     x_ref, y_ref = np.meshgrid(np.arange(0, width), np.arange(0, height))
     x_ref, y_ref = x_ref.reshape([-1]), y_ref.reshape([-1])
@@ -176,10 +121,10 @@ def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, i
     xyz_src = np.matmul(np.matmul(extrinsics_src, np.linalg.inv(extrinsics_ref)),
                         np.vstack((xyz_ref, np.ones_like(x_ref))))[:3]
     # source view x, y
-    K_xyz_src = np.matmul(intrinsics_src, xyz_src)
-    xy_src = K_xyz_src[:2] / K_xyz_src[2:3]
+    k_xyz_src = np.matmul(intrinsics_src, xyz_src)
+    xy_src = k_xyz_src[:2] / k_xyz_src[2:3]
 
-    ## step2. reproject the source view points with source view depth estimation
+    # step2. reproject the source view points with source view depth estimation
     # find the depth estimation of the source view
     x_src = xy_src[0].reshape([height, width]).astype(np.float32)
     y_src = xy_src[1].reshape([height, width]).astype(np.float32)
@@ -195,8 +140,8 @@ def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, i
                                 np.vstack((xyz_src, np.ones_like(x_ref))))[:3]
     # source view x, y, depth
     depth_reprojected = xyz_reprojected[2].reshape([height, width]).astype(np.float32)
-    K_xyz_reprojected = np.matmul(intrinsics_ref, xyz_reprojected)
-    xy_reprojected = K_xyz_reprojected[:2] / K_xyz_reprojected[2:3]
+    k_xyz_reprojected = np.matmul(intrinsics_ref, xyz_reprojected)
+    xy_reprojected = k_xyz_reprojected[:2] / k_xyz_reprojected[2:3]
     x_reprojected = xy_reprojected[0].reshape([height, width]).astype(np.float32)
     y_reprojected = xy_reprojected[1].reshape([height, width]).astype(np.float32)
 
@@ -207,8 +152,8 @@ def check_geometric_consistency(depth_ref, intrinsics_ref, extrinsics_ref, depth
                                 geo_pixel_thres, geo_depth_thres):
     width, height = depth_ref.shape[1], depth_ref.shape[0]
     x_ref, y_ref = np.meshgrid(np.arange(0, width), np.arange(0, height))
-    depth_reprojected, x2d_reprojected, y2d_reprojected, x2d_src, y2d_src = reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref,
-                                                     depth_src, intrinsics_src, extrinsics_src)
+    depth_reprojected, x2d_reprojected, y2d_reprojected, x2d_src, y2d_src = reproject_with_depth(
+        depth_ref, intrinsics_ref, extrinsics_ref, depth_src, intrinsics_src, extrinsics_src)
     # print(depth_ref.shape)
     # print(depth_reprojected.shape)
     # check |p_reproj-p_1| < 1
@@ -225,7 +170,8 @@ def check_geometric_consistency(depth_ref, intrinsics_ref, extrinsics_ref, depth
     return mask, depth_reprojected, x2d_src, y2d_src
 
 
-def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_depth_thres, photo_thres, img_wh, geo_mask_thres):
+def filter_depth(
+        scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_depth_thres, photo_thres, img_wh, geo_mask_thres):
     # the pair file
     pair_file = os.path.join(scan_folder, "pair.txt")
     # for the final point cloud
@@ -233,69 +179,62 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
     vertex_colors = []
 
     pair_data = read_pair_file(pair_file)
-    nviews = len(pair_data)
-    
 
     # for each reference view and the corresponding source views
     for ref_view, src_views in pair_data:
         
         # load the reference image
-        ref_img, original_h, original_w = read_img(os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(ref_view)),img_wh)
-        ref_intrinsics, ref_extrinsics = read_cam_file(
+        ref_img, original_h, original_w = read_image(
+            os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(ref_view)), max(img_wh))
+        ref_intrinsics, ref_extrinsics, _ = read_cam_file(
             os.path.join(scan_folder, 'cams_1/{:0>8}_cam.txt'.format(ref_view)))[0:2]
         ref_intrinsics[0] *= img_wh[0]/original_w
         ref_intrinsics[1] *= img_wh[1]/original_h
         
         # load the estimated depth of the reference view
-        ref_depth_est = read_pfm(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(ref_view)))[0]
+        ref_depth_est = read_map(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(ref_view)))
         ref_depth_est = np.squeeze(ref_depth_est, 2)
         # load the photometric mask of the reference view
-        confidence = read_pfm(os.path.join(out_folder, 'confidence/{:0>8}.pfm'.format(ref_view)))[0]
+        confidence = read_map(os.path.join(out_folder, 'confidence/{:0>8}.pfm'.format(ref_view)))
         
         photo_mask = confidence > photo_thres
         photo_mask = np.squeeze(photo_mask, 2)
-        
 
         all_srcview_depth_ests = []
-        
         # compute the geometric mask
         geo_mask_sum = 0
         for src_view in src_views:
             # camera parameters of the source view
-            _, original_h, original_w = read_img(os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(src_view)), img_wh)
-            src_intrinsics, src_extrinsics = read_cam_file(
+            _, original_h, original_w = read_image(
+                os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(src_view)), max(img_wh))
+            src_intrinsics, src_extrinsics, _ = read_cam_file(
                 os.path.join(scan_folder, 'cams_1/{:0>8}_cam.txt'.format(src_view)))[0:2]
             src_intrinsics[0] *= img_wh[0]/original_w
             src_intrinsics[1] *= img_wh[1]/original_h
             
             # the estimated depth of the source view
-            src_depth_est = read_pfm(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(src_view)))[0]
+            src_depth_est = read_map(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(src_view)))
 
-            geo_mask, depth_reprojected, x2d_src, y2d_src = check_geometric_consistency(ref_depth_est, ref_intrinsics, ref_extrinsics,
-                                                                      src_depth_est,
-                                                                      src_intrinsics, src_extrinsics,
-                                                                      geo_pixel_thres, geo_depth_thres)
+            geo_mask, depth_reprojected, _, _ = check_geometric_consistency(
+                ref_depth_est, ref_intrinsics, ref_extrinsics, src_depth_est, src_intrinsics, src_extrinsics,
+                geo_pixel_thres, geo_depth_thres)
             geo_mask_sum += geo_mask.astype(np.int32)
             all_srcview_depth_ests.append(depth_reprojected)
-            
 
         depth_est_averaged = (sum(all_srcview_depth_ests) + ref_depth_est) / (geo_mask_sum + 1)
-        
         geo_mask = geo_mask_sum >= geo_mask_thres
         final_mask = np.logical_and(photo_mask, geo_mask)
         
         os.makedirs(os.path.join(out_folder, "mask"), exist_ok=True)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_photo.png".format(ref_view)), photo_mask)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_geo.png".format(ref_view)), geo_mask)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_final.png".format(ref_view)), final_mask)
-        
+        save_image(os.path.join(out_folder, "mask/{:0>8}_photo.png".format(ref_view)), photo_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_geo.png".format(ref_view)), geo_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_final.png".format(ref_view)), final_mask)
 
         if args.display:
-            import cv2
             cv2.imshow('ref_img', ref_img[:, :, ::-1])
-            cv2.imshow('ref_depth', ref_depth_est )
+            cv2.imshow('ref_depth', ref_depth_est)
             cv2.imshow('ref_depth * photo_mask', ref_depth_est * photo_mask.astype(np.float32))
-            cv2.imshow('ref_depth * geo_mask', ref_depth_est * geo_mask.astype(np.float32) )
+            cv2.imshow('ref_depth * geo_mask', ref_depth_est * geo_mask.astype(np.float32))
             cv2.imshow('ref_depth * mask', ref_depth_est * final_mask.astype(np.float32))
             cv2.waitKey(1)
 
@@ -307,10 +246,8 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
         x, y, depth = x[valid_points], y[valid_points], depth_est_averaged[valid_points]
         
         color = ref_img[valid_points]
-        xyz_ref = np.matmul(    np.linalg.inv(ref_intrinsics),
-                            np.vstack((x, y, np.ones_like(x))) * depth)
-        xyz_world = np.matmul(np.linalg.inv(ref_extrinsics),
-                              np.vstack((xyz_ref, np.ones_like(x))))[:3]
+        xyz_ref = np.matmul(np.linalg.inv(ref_intrinsics), np.vstack((x, y, np.ones_like(x))) * depth)
+        xyz_world = np.matmul(np.linalg.inv(ref_extrinsics), np.vstack((xyz_ref, np.ones_like(x))))[:3]
         vertexs.append(xyz_world.transpose((1, 0)))
         vertex_colors.append((color * 255).astype(np.uint8))
 
@@ -333,92 +270,82 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
 if __name__ == '__main__':
     # step1. save all the depth maps and the masks in outputs directory
     save_depth()
-    img_wh = (2688,1792)
-    
-    
-    
+    img_wh = (2688, 1792)
+
     if args.split == "test":
-        scans = ['botanical_garden', 'boulders', 'bridge', 'door',
-                'exhibition_hall', 'lecture_room', 'living_room', 'lounge',
-                'observatory', 'old_computer', 'statue', 'terrace_2']
-        
-        
-        
-        geo_mask_thres = {'botanical_garden':1,  # 30 images, outdoor
-                'boulders':1, # 26 images, outdoor
-                'bridge':4,  # 110 images, outdoor
-                'door':1, # 6 images, indoor
-                'exhibition_hall':1,  # 68 images, indoor
-                'lecture_room':1, # 23 images, indoor
-                'living_room':2, # 65 images, indoor
-                'lounge':1,# 10 images, indoor
-                'observatory':1, # 27 images, outdoor
-                'old_computer':1, # 54 images, indoor
-                'statue':1,  # 10 images, indoor
-                'terrace_2':1 # 13 images, outdoor
-                }
-        num_images = {'botanical_garden':30,  # 30 images, outdoor
-                'boulders':26, # 26 images, outdoor
-                'bridge':110,  # 110 images, outdoor
-                'door':6, # 6 images, indoor
-                'exhibition_hall':68,  # 68 images, indoor
-                'lecture_room':23, # 23 images, indoor
-                'living_room':65, # 65 images, indoor
-                'lounge':10,# 10 images, indoor
-                'observatory':27, # 27 images, outdoor
-                'old_computer':54, # 54 images, indoor
-                'statue':10,  # 10 images, indoor
-                'terrace_2':13 # 13 images, outdoor
-                }
+        scans = ['botanical_garden', 'boulders', 'bridge', 'door', 'exhibition_hall', 'lecture_room', 'living_room',
+                 'lounge', 'observatory', 'old_computer', 'statue', 'terrace_2']
+        geo_mask_thres = {'botanical_garden': 1,  # 30 images, outdoor
+                          'boulders': 1,  # 26 images, outdoor
+                          'bridge': 4,  # 110 images, outdoor
+                          'door': 1,  # 6 images, indoor
+                          'exhibition_hall': 1,  # 68 images, indoor
+                          'lecture_room': 1,  # 23 images, indoor
+                          'living_room': 2,  # 65 images, indoor
+                          'lounge': 1,  # 10 images, indoor
+                          'observatory': 1,  # 27 images, outdoor
+                          'old_computer': 1,  # 54 images, indoor
+                          'statue': 1,  # 10 images, indoor
+                          'terrace_2': 1  # 13 images, outdoor
+                          }
+        num_images = {'botanical_garden': 30,  # 30 images, outdoor
+                      'boulders': 26,  # 26 images, outdoor
+                      'bridge': 110,  # 110 images, outdoor
+                      'door': 6,  # 6 images, indoor
+                      'exhibition_hall': 68,  # 68 images, indoor
+                      'lecture_room': 23,  # 23 images, indoor
+                      'living_room': 65,  # 65 images, indoor
+                      'lounge': 10,  # 10 images, indoor
+                      'observatory': 27,  # 27 images, outdoor
+                      'old_computer': 54,  # 54 images, indoor
+                      'statue': 10,  # 10 images, indoor
+                      'terrace_2': 13  # 13 images, outdoor
+                      }
         for scan in scans:
             start_time = time.time()
             scan_folder = os.path.join(args.testpath, scan)
             out_folder = os.path.join(args.outdir, scan)
             # step2. filter saved depth maps with geometric constraints
-            filter_depth(scan_folder, out_folder, os.path.join(args.outdir, scan + '.ply'), 
-                        args.geo_pixel_thres, args.geo_depth_thres, args.photo_thres, img_wh, geo_mask_thres[scan]) 
+            filter_depth(scan_folder, out_folder, os.path.join(args.outdir, scan + '.ply'),  args.geo_pixel_thres,
+                         args.geo_depth_thres, args.photo_thres, img_wh, geo_mask_thres[scan])
             print('scan: '+scan+' time = {:3f}'.format(time.time() - start_time))
 
     elif args.split == "train":
-        scans = ['courtyard', 'delivery_area', 'electro', 'facade',
-                'kicker', 'meadow', 'office', 'pipes', 'playground',
-                'relief', 'relief_2', 'terrace', 'terrains']
-        
-        
-        geo_mask_thres = {'courtyard':1,  # 38 images, outdoor
-                'delivery_area':1, # 44 images, indoor
-                'electro':1,  # 45 images, outdoor
-                'facade':4, # 76 images, outdoor
-                'kicker':1,  # 31 images, indoor
-                'meadow':1, # 15 images, outdoor
-                'office':1, # 26 images, indoor
-                'pipes':1,# 14 images, indoor
-                'playground':1, # 38 images, outdoor
-                'relief':1, # 31 images, indoor
-                'relief_2':1, # 31 images, indoor
-                'terrace':1,  # 23 images, outdoor
-                'terrains':1 # 42 images, indoor
-                }
-        
-        num_images = {'courtyard':38,  # 38 images, outdoor
-                'delivery_area':44, # 44 images, indoor
-                'electro':45,  # 45 images, outdoor
-                'facade':76, # 76 images, outdoor
-                'kicker':31,  # 31 images, indoor
-                'meadow':15, # 15 images, outdoor
-                'office':26, # 26 images, indoor
-                'pipes':14,# 14 images, indoor
-                'playground':38, # 38 images, outdoor
-                'relief':31, # 31 images, indoor
-                'relief_2':31, # 31 images, indoor
-                'terrace':23,  # 23 images, outdoor
-                'terrains':42 # 42 images, indoor
-                }
+        scans = ['courtyard', 'delivery_area', 'electro', 'facade', 'kicker', 'meadow', 'office', 'pipes', 'playground',
+                 'relief', 'relief_2', 'terrace', 'terrains']
+        geo_mask_thres = {'courtyard': 1,  # 38 images, outdoor
+                          'delivery_area': 1,  # 44 images, indoor
+                          'electro': 1,  # 45 images, outdoor
+                          'facade': 4,  # 76 images, outdoor
+                          'kicker': 1,  # 31 images, indoor
+                          'meadow': 1,  # 15 images, outdoor
+                          'office': 1,  # 26 images, indoor
+                          'pipes': 1,  # 14 images, indoor
+                          'playground': 1,  # 38 images, outdoor
+                          'relief': 1,  # 31 images, indoor
+                          'relief_2': 1,  # 31 images, indoor
+                          'terrace': 1,  # 23 images, outdoor
+                          'terrains': 1  # 42 images, indoor
+                          }
+        num_images = {'courtyard': 38,  # 38 images, outdoor
+                      'delivery_area': 44,  # 44 images, indoor
+                      'electro': 45,  # 45 images, outdoor
+                      'facade': 76,  # 76 images, outdoor
+                      'kicker': 31,  # 31 images, indoor
+                      'meadow': 15,  # 15 images, outdoor
+                      'office': 26,  # 26 images, indoor
+                      'pipes': 14,  # 14 images, indoor
+                      'playground': 38,  # 38 images, outdoor
+                      'relief': 31,  # 31 images, indoor
+                      'relief_2': 31,  # 31 images, indoor
+                      'terrace': 23,  # 23 images, outdoor
+                      'terrains': 42  # 42 images, indoor
+                      }
         for scan in scans:
             start_time = time.time()
             scan_folder = os.path.join(args.testpath, scan)
             out_folder = os.path.join(args.outdir, scan)
             # step2. filter saved depth maps with geometric constraints
-            filter_depth(scan_folder, out_folder, os.path.join(args.outdir, scan + '.ply'), 
-                        args.geo_pixel_thres, args.geo_depth_thres, args.photo_thres, img_wh, geo_mask_thres[scan])   
+            filter_depth(scan_folder, out_folder, os.path.join(args.outdir, scan + '.ply'), args.geo_pixel_thres,
+                         args.geo_depth_thres, args.photo_thres, img_wh, geo_mask_thres[scan])
             print('scan: '+scan+' time = {:3f}'.format(time.time() - start_time))

--- a/eval_tank.py
+++ b/eval_tank.py
@@ -1,25 +1,17 @@
 import argparse
 import os
-import torch
 import torch.nn as nn
 import torch.nn.parallel
 import torch.backends.cudnn as cudnn
-import torch.optim as optim
 from torch.utils.data import DataLoader
-from torch.autograd import Variable
-import torch.nn.functional as F
-import numpy as np
 import time
 from datasets import find_dataset_def
 from models import *
 from utils import *
 import sys
-from datasets.data_io import read_pfm, save_pfm
+from datasets.data_io import read_cam_file, read_pair_file, read_image, read_map, save_image, save_map
 import cv2
 from plyfile import PlyData, PlyElement
-from PIL import Image
-import math
-# import scipy.signal as signal
 
 cudnn.benchmark = True
 
@@ -38,22 +30,23 @@ parser.add_argument('--loadckpt', default=None, help='load a specific checkpoint
 parser.add_argument('--outdir', default='./outputs', help='output dir')
 parser.add_argument('--display', action='store_true', help='display depth images and masks')
 
-parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1,2,2], 
-        help='num of iteration of patchmatch on stages 1,2,3')
-parser.add_argument('--patchmatch_num_sample', nargs='+', type=int, default=[8,8,16], 
-        help='num of generated samples in local perturbation on stages 1,2,3')
+parser.add_argument('--patchmatch_iteration', nargs='+', type=int, default=[1, 2, 2],
+                    help='num of iteration of patchmatch on stages 1,2,3')
+parser.add_argument('--patchmatch_num_sample', nargs='+', type=int, default=[8, 8, 16],
+                    help='num of generated samples in local perturbation on stages 1,2,3')
 parser.add_argument('--patchmatch_interval_scale', nargs='+', type=float, default=[0.005, 0.0125, 0.025], 
-        help='normalized interval in inverse depth range to generate samples in local perturbation')
-parser.add_argument('--patchmatch_range', nargs='+', type=int, default=[6,4,2], 
-        help='fixed offset of sampling points for propogation of patchmatch on stages 1,2,3')
-parser.add_argument('--propagate_neighbors', nargs='+', type=int, default=[0,8,16], 
-        help='num of neighbors for adaptive propagation on stages 1,2,3')
-parser.add_argument('--evaluate_neighbors', nargs='+', type=int, default=[9,9,9], 
-        help='num of neighbors for adaptive matching cost aggregation of adaptive evaluation on stages 1,2,3')
+                    help='normalized interval in inverse depth range to generate samples in local perturbation')
+parser.add_argument('--patchmatch_range', nargs='+', type=int, default=[6, 4, 2],
+                    help='fixed offset of sampling points for propogation of patchmatch on stages 1,2,3')
+parser.add_argument('--propagate_neighbors', nargs='+', type=int, default=[0, 8, 16],
+                    help='num of neighbors for adaptive propagation on stages 1,2,3')
+parser.add_argument('--evaluate_neighbors', nargs='+', type=int, default=[9, 9, 9],
+                    help='num of neighbors for adaptive matching cost aggregation of adaptive evaluation on stages 1,2,3')
 
-parser.add_argument('--geo_pixel_thres', type=float, default=1, help='pixel threshold for geometric consistency filtering')
-parser.add_argument('--geo_depth_thres', type=float, default=0.01, help='depth threshold for geometric consistency filtering')
-
+parser.add_argument('--geo_pixel_thres', type=float, default=1,
+                    help='pixel threshold for geometric consistency filtering')
+parser.add_argument('--geo_depth_thres', type=float, default=0.01,
+                    help='depth threshold for geometric consistency filtering')
 
 
 # parse arguments and check
@@ -61,65 +54,23 @@ args = parser.parse_args()
 print("argv:", sys.argv[1:])
 print_args(args)
 
-# read an image
-def read_img(filename, img_wh):
-    img = Image.open(filename)
-    # scale 0~255 to 0~1
-    np_img = np.array(img, dtype=np.float32) / 255.
-    np_img = cv2.resize(np_img, img_wh, interpolation=cv2.INTER_LINEAR)
-    
-    return np_img
-
-def read_cam_file(filename):
-    with open(filename) as f:
-        lines = [line.rstrip() for line in f.readlines()]
-    # extrinsics: line [1,5), 4x4 matrix
-    extrinsics = np.fromstring(' '.join(lines[1:5]), dtype=np.float32, sep=' ')
-    extrinsics = extrinsics.reshape((4, 4))
-    # intrinsics: line [7-10), 3x3 matrix
-    intrinsics = np.fromstring(' '.join(lines[7:10]), dtype=np.float32, sep=' ')
-    intrinsics = intrinsics.reshape((3, 3))
-    
-    return intrinsics, extrinsics
-
-# save a binary mask
-def save_mask(filename, mask):
-    assert mask.dtype == np.bool
-    mask = mask.astype(np.uint8) * 255
-    Image.fromarray(mask).save(filename)
-
-def save_depth_img(filename, depth):
-    # assert mask.dtype == np.bool
-    depth = depth * 255
-    depth = depth.astype(np.uint8)
-    Image.fromarray(depth).save(filename)
-
-
-def read_pair_file(filename):
-    data = []
-    with open(filename) as f:
-        num_viewpoint = int(f.readline())
-        # 49 viewpoints
-        for view_idx in range(num_viewpoint):
-            ref_view = int(f.readline().rstrip())
-            src_views = [int(x) for x in f.readline().rstrip().split()[1::2]]
-            if len(src_views) != 0:
-                data.append((ref_view, src_views))
-    return data
-
 
 # run MVS model to save depth maps
 def save_depth():
     # dataset, dataloader
-    MVSDataset = find_dataset_def(args.dataset)
-    test_dataset = MVSDataset(args.testpath, args.split, args.n_views)
-    TestImgLoader = DataLoader(test_dataset, args.batch_size, shuffle=False, num_workers=4, drop_last=False)
+    mvs_dataset = find_dataset_def(args.dataset)
+    test_dataset = mvs_dataset(args.testpath, args.split, args.n_views)
+    image_loader = DataLoader(test_dataset, args.batch_size, shuffle=False, num_workers=4, drop_last=False)
 
     # model
-    model = PatchmatchNet(patchmatch_interval_scale=args.patchmatch_interval_scale,
-                propagation_range = args.patchmatch_range, patchmatch_iteration=args.patchmatch_iteration, 
-                patchmatch_num_sample = args.patchmatch_num_sample, 
-                propagate_neighbors=args.propagate_neighbors, evaluate_neighbors=args.evaluate_neighbors)
+    model = PatchmatchNet(
+        patchmatch_interval_scale=args.patchmatch_interval_scale,
+        propagation_range=args.patchmatch_range,
+        patchmatch_iteration=args.patchmatch_iteration,
+        patchmatch_num_sample=args.patchmatch_num_sample,
+        propagate_neighbors=args.propagate_neighbors,
+        evaluate_neighbors=args.evaluate_neighbors
+    )
     model = nn.DataParallel(model)
     model.cuda()
 
@@ -129,7 +80,7 @@ def save_depth():
     model.eval()
     
     with torch.no_grad():
-        for batch_idx, sample in enumerate(TestImgLoader):
+        for batch_idx, sample in enumerate(image_loader):
             start_time = time.time()
             sample_cuda = tocuda(sample)
             refined_depth, confidence, _ = model(sample_cuda["imgs"], sample_cuda["proj_matrices"],
@@ -138,7 +89,7 @@ def save_depth():
             confidence = tensor2numpy(confidence)
 
             del sample_cuda
-            print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(TestImgLoader), time.time() - start_time))
+            print('Iter {}/{}, time = {:.3f}'.format(batch_idx, len(image_loader), time.time() - start_time))
             filenames = sample["filename"]
 
             # save depth maps and confidence maps
@@ -149,16 +100,15 @@ def save_depth():
                 os.makedirs(confidence_filename.rsplit('/', 1)[0], exist_ok=True)
                 # save depth maps
                 depth_est = np.squeeze(depth_est, 0)
-                save_pfm(depth_filename, depth_est)
+                save_map(depth_filename, depth_est)
                 # save confidence maps
-                save_pfm(confidence_filename, photometric_confidence)
-                
+                save_map(confidence_filename, photometric_confidence)
 
 
 # project the reference point cloud into the source view, then project back
 def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, intrinsics_src, extrinsics_src):
     width, height = depth_ref.shape[1], depth_ref.shape[0]
-    ## step1. project reference pixels to the source view
+    # step1. project reference pixels to the source view
     # reference view x, y
     x_ref, y_ref = np.meshgrid(np.arange(0, width), np.arange(0, height))
     x_ref, y_ref = x_ref.reshape([-1]), y_ref.reshape([-1])
@@ -169,10 +119,10 @@ def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, i
     xyz_src = np.matmul(np.matmul(extrinsics_src, np.linalg.inv(extrinsics_ref)),
                         np.vstack((xyz_ref, np.ones_like(x_ref))))[:3]
     # source view x, y
-    K_xyz_src = np.matmul(intrinsics_src, xyz_src)
-    xy_src = K_xyz_src[:2] / K_xyz_src[2:3]
+    k_xyz_src = np.matmul(intrinsics_src, xyz_src)
+    xy_src = k_xyz_src[:2] / k_xyz_src[2:3]
 
-    ## step2. reproject the source view points with source view depth estimation
+    # step2. reproject the source view points with source view depth estimation
     # find the depth estimation of the source view
     x_src = xy_src[0].reshape([height, width]).astype(np.float32)
     y_src = xy_src[1].reshape([height, width]).astype(np.float32)
@@ -188,8 +138,8 @@ def reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref, depth_src, i
                                 np.vstack((xyz_src, np.ones_like(x_ref))))[:3]
     # source view x, y, depth
     depth_reprojected = xyz_reprojected[2].reshape([height, width]).astype(np.float32)
-    K_xyz_reprojected = np.matmul(intrinsics_ref, xyz_reprojected)
-    xy_reprojected = K_xyz_reprojected[:2] / K_xyz_reprojected[2:3]
+    k_xyz_reprojected = np.matmul(intrinsics_ref, xyz_reprojected)
+    xy_reprojected = k_xyz_reprojected[:2] / k_xyz_reprojected[2:3]
     x_reprojected = xy_reprojected[0].reshape([height, width]).astype(np.float32)
     y_reprojected = xy_reprojected[1].reshape([height, width]).astype(np.float32)
 
@@ -200,8 +150,8 @@ def check_geometric_consistency(depth_ref, intrinsics_ref, extrinsics_ref, depth
                                 geo_pixel_thres=1, geo_depth_thres=0.01, dynamic_consistency_check=False):
     width, height = depth_ref.shape[1], depth_ref.shape[0]
     x_ref, y_ref = np.meshgrid(np.arange(0, width), np.arange(0, height))
-    depth_reprojected, x2d_reprojected, y2d_reprojected, x2d_src, y2d_src = reproject_with_depth(depth_ref, intrinsics_ref, extrinsics_ref,
-                                                     depth_src, intrinsics_src, extrinsics_src)
+    depth_reprojected, x2d_reprojected, y2d_reprojected, x2d_src, y2d_src = reproject_with_depth(
+        depth_ref, intrinsics_ref, extrinsics_ref, depth_src, intrinsics_src, extrinsics_src)
     # print(depth_ref.shape)
     # print(depth_reprojected.shape)
     # check |p_reproj-p_1| < 1
@@ -221,7 +171,9 @@ def check_geometric_consistency(depth_ref, intrinsics_ref, extrinsics_ref, depth
     return mask, depth_reprojected, x2d_src, y2d_src
 
 
-def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_depth_thres, photo_thres, img_wh, image_sizes, geo_mask_thres, n_views):
+def filter_depth(
+        scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_depth_thres, photo_thres, img_wh, image_sizes,
+        geo_mask_thres):
     # the pair file
     pair_file = os.path.join(scan_folder, "pair.txt")
     # for the final point cloud
@@ -229,76 +181,65 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
     vertex_colors = []
 
     pair_data = read_pair_file(pair_file)
-    nviews = len(pair_data)
     original_w, original_h = image_sizes
     
     # for each reference view and the corresponding source views
     for ref_view, src_views in pair_data:
         # load the camera parameters
-        ref_intrinsics, ref_extrinsics = read_cam_file(
+        ref_intrinsics, ref_extrinsics, _ = read_cam_file(
             os.path.join(scan_folder, 'cams_1/{:0>8}_cam.txt'.format(ref_view)))
         ref_intrinsics[0] *= img_wh[0]/original_w
         ref_intrinsics[1] *= img_wh[1]/original_h
         # load the reference image
-        ref_img = read_img(os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(ref_view)),img_wh)
+        ref_img, _, _ = read_image(os.path.join(scan_folder, 'images/{:0>8}.jpg'.format(ref_view)), max(img_wh))
         
         # load the estimated depth of the reference view
-        ref_depth_est = read_pfm(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(ref_view)))[0]
+        ref_depth_est = read_map(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(ref_view)))
         ref_depth_est = np.squeeze(ref_depth_est, 2)
         # load the photometric mask of the reference view
-        confidence = read_pfm(os.path.join(out_folder, 'confidence/{:0>8}.pfm'.format(ref_view)))[0]
+        confidence = read_map(os.path.join(out_folder, 'confidence/{:0>8}.pfm'.format(ref_view)))
         
         photo_mask = confidence > photo_thres
         photo_mask = np.squeeze(photo_mask, 2)
-        
 
         all_srcview_depth_ests = []
-        
-
         # compute the geometric mask
         geo_mask_sum = 0
         n_views = len(src_views)+1
         for i in range(n_views-1):
             src_view = src_views[i]
             
-            src_intrinsics, src_extrinsics = read_cam_file(
+            src_intrinsics, src_extrinsics, _ = read_cam_file(
                 os.path.join(scan_folder, 'cams_1/{:0>8}_cam.txt'.format(src_view)))
             src_intrinsics[0] *= img_wh[0]/original_w
             src_intrinsics[1] *= img_wh[1]/original_h
-            
-            
-            # the estimated depth of the source view
-            src_depth_est = read_pfm(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(src_view)))[0]
 
-            geo_mask, depth_reprojected, _, _ = check_geometric_consistency(ref_depth_est, ref_intrinsics, ref_extrinsics,
-                                                                      src_depth_est,
-                                                                      src_intrinsics, src_extrinsics,
-                                                                      geo_pixel_thres, geo_depth_thres)
+            # the estimated depth of the source view
+            src_depth_est = read_map(os.path.join(out_folder, 'depth_est/{:0>8}.pfm'.format(src_view)))
+
+            geo_mask, depth_reprojected, _, _ = check_geometric_consistency(
+                ref_depth_est, ref_intrinsics, ref_extrinsics, src_depth_est, src_intrinsics, src_extrinsics,
+                geo_pixel_thres, geo_depth_thres)
             geo_mask_sum += geo_mask.astype(np.int32)
             all_srcview_depth_ests.append(depth_reprojected)
-            
 
         depth_est_averaged = (sum(all_srcview_depth_ests) + ref_depth_est) / (geo_mask_sum + 1)
-        
         geo_mask = geo_mask_sum >= geo_mask_thres
         final_mask = np.logical_and(photo_mask, geo_mask)
-        
 
         os.makedirs(os.path.join(out_folder, "mask"), exist_ok=True)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_photo.png".format(ref_view)), photo_mask)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_geo.png".format(ref_view)), geo_mask)
-        save_mask(os.path.join(out_folder, "mask/{:0>8}_final.png".format(ref_view)), final_mask)
-        
+        save_image(os.path.join(out_folder, "mask/{:0>8}_photo.png".format(ref_view)), photo_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_geo.png".format(ref_view)), geo_mask)
+        save_image(os.path.join(out_folder, "mask/{:0>8}_final.png".format(ref_view)), final_mask)
 
-        print("processing {}, ref-view{:0>2}, geo_mask:{:3f} photo_mask:{:3f} final_mask: {:3f}".format(scan_folder, ref_view,
-                                                                geo_mask.mean(), photo_mask.mean(), final_mask.mean()))
+        print("processing {}, ref-view{:0>2}, geo_mask:{:3f} photo_mask:{:3f} final_mask: {:3f}".format(
+            scan_folder, ref_view, geo_mask.mean(), photo_mask.mean(), final_mask.mean()))
 
         if args.display:
-            import cv2
             cv2.imshow('ref_img', ref_img[:, :, ::-1])
-            cv2.imshow('ref_depth', ref_depth_est )
+            cv2.imshow('ref_depth', ref_depth_est)
             cv2.imshow('ref_depth * photo_mask', ref_depth_est * photo_mask.astype(np.float32))
-            cv2.imshow('ref_depth * geo_mask', ref_depth_est * geo_mask.astype(np.float32) )
+            cv2.imshow('ref_depth * geo_mask', ref_depth_est * geo_mask.astype(np.float32))
             cv2.imshow('ref_depth * mask', ref_depth_est * final_mask.astype(np.float32))
             cv2.waitKey(1)
 
@@ -310,13 +251,10 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
         x, y, depth = x[valid_points], y[valid_points], depth_est_averaged[valid_points]
         
         color = ref_img[valid_points]
-        xyz_ref = np.matmul(    np.linalg.inv(ref_intrinsics),
-                            np.vstack((x, y, np.ones_like(x))) * depth)
-        xyz_world = np.matmul(np.linalg.inv(ref_extrinsics),
-                              np.vstack((xyz_ref, np.ones_like(x))))[:3]
+        xyz_ref = np.matmul(np.linalg.inv(ref_intrinsics), np.vstack((x, y, np.ones_like(x))) * depth)
+        xyz_world = np.matmul(np.linalg.inv(ref_extrinsics), np.vstack((xyz_ref, np.ones_like(x))))[:3]
         vertexs.append(xyz_world.transpose((1, 0)))
         vertex_colors.append((color * 255).astype(np.uint8))
-
 
     vertexs = np.concatenate(vertexs, axis=0)
     vertex_colors = np.concatenate(vertex_colors, axis=0)
@@ -337,76 +275,67 @@ def filter_depth(scan_folder, out_folder, plyfilename, geo_pixel_thres, geo_dept
 if __name__ == '__main__':
     # step1. save all the depth maps and the masks in outputs directory
     save_depth()
-    img_wh=(1920, 1056)
-    
-    
+    img_wh = (1920, 1056)
+
     # intermediate dataset
     if args.split == "intermediate":
-
-        scans = ['Family', 'Francis', 'Horse', 'Lighthouse',
-                'M60', 'Panther', 'Playground', 'Train']
-        
+        scans = ['Family', 'Francis', 'Horse', 'Lighthouse', 'M60', 'Panther', 'Playground', 'Train']
         image_sizes = {'Family': (1920, 1080),
-                            'Francis': (1920, 1080),
-                            'Horse': (1920, 1080),
-                            'Lighthouse': (2048, 1080),
-                            'M60': (2048, 1080),
-                            'Panther': (2048, 1080),
-                            'Playground': (1920, 1080),
-                            'Train': (1920, 1080)}
+                       'Francis': (1920, 1080),
+                       'Horse': (1920, 1080),
+                       'Lighthouse': (2048, 1080),
+                       'M60': (2048, 1080),
+                       'Panther': (2048, 1080),
+                       'Playground': (1920, 1080),
+                       'Train': (1920, 1080)}
         geo_mask_thres = {'Family': 5,
-                            'Francis': 6,
-                            'Horse': 4,
-                            'Lighthouse': 6,
-                            'M60': 5,
-                            'Panther': 5,
-                            'Playground': 6,
-                            'Train': 5}
+                          'Francis': 6,
+                          'Horse': 4,
+                          'Lighthouse': 6,
+                          'M60': 5,
+                          'Panther': 5,
+                          'Playground': 6,
+                          'Train': 5}
         photo_thres = {'Family': 0.8,
-                            'Francis': 0.8,
-                            'Horse': 0.6,
-                            'Lighthouse': 0.8,
-                            'M60': 0.8,
-                            'Panther': 0.8,
-                            'Playground': 0.8,
-                            'Train': 0.8}
+                       'Francis': 0.8,
+                       'Horse': 0.6,
+                       'Lighthouse': 0.8,
+                       'M60': 0.8,
+                       'Panther': 0.8,
+                       'Playground': 0.8,
+                       'Train': 0.8}
         for scan in scans:
-            
             scan_folder = os.path.join(args.testpath, args.split, scan)
             out_folder = os.path.join(args.outdir, scan)
             # step2. filter saved depth maps with geometric constraints
-            
-            filter_depth(scan_folder, out_folder, os.path.join(args.outdir, scan + '.ply'), 
-                args.geo_pixel_thres, args.geo_depth_thres, photo_thres[scan], img_wh, image_sizes[scan], geo_mask_thres[scan], args.n_views) 
+            filter_depth(
+                scan_folder, out_folder, os.path.join(args.outdir, scan + '.ply'), args.geo_pixel_thres,
+                args.geo_depth_thres, photo_thres[scan], img_wh, image_sizes[scan], geo_mask_thres[scan])
     # advanced dataset
     elif args.split == "advanced":
-
-        scans = ['Auditorium', 'Ballroom', 'Courtroom',
-                'Museum', 'Palace', 'Temple']
-        
+        scans = ['Auditorium', 'Ballroom', 'Courtroom', 'Museum', 'Palace', 'Temple']
         image_sizes = {'Auditorium': (1920, 1080),
-                                'Ballroom': (1920, 1080),
-                                'Courtroom': (1920, 1080),
-                                'Museum': (1920, 1080),
-                                'Palace': (1920, 1080),
-                                'Temple': (1920, 1080)}
+                       'Ballroom': (1920, 1080),
+                       'Courtroom': (1920, 1080),
+                       'Museum': (1920, 1080),
+                       'Palace': (1920, 1080),
+                       'Temple': (1920, 1080)}
         geo_mask_thres = {'Auditorium': 3,
-                            'Ballroom': 4,
-                            'Courtroom': 4,
-                            'Museum': 4,
-                            'Palace': 5,
-                            'Temple': 4}
-
+                          'Ballroom': 4,
+                          'Courtroom': 4,
+                          'Museum': 4,
+                          'Palace': 5,
+                          'Temple': 4}
         photo_thres = {'Auditorium': 0.8,
-                            'Ballroom': 0.8,
-                            'Courtroom': 0.8,
-                            'Museum': 0.8,
-                            'Palace': 0.8,
-                            'Temple': 0.8}
+                       'Ballroom': 0.8,
+                       'Courtroom': 0.8,
+                       'Museum': 0.8,
+                       'Palace': 0.8,
+                       'Temple': 0.8}
         for scan in scans:
-            
             scan_folder = os.path.join(args.testpath, args.split, scan)
             out_folder = os.path.join(args.outdir, scan)
             # step2. filter saved depth maps with geometric constraints
-            filter_depth(scan_folder, out_folder, os.path.join(args.outdir, scan + '.ply'), 
-                args.geo_pixel_thres, args.geo_depth_thres, photo_thres[scan], img_wh, image_sizes[scan], geo_mask_thres[scan], args.n_views) 
+            filter_depth(
+                scan_folder, out_folder, os.path.join(args.outdir, scan + '.ply'), args.geo_pixel_thres,
+                args.geo_depth_thres, photo_thres[scan], img_wh, image_sizes[scan], geo_mask_thres[scan])


### PR DESCRIPTION
All I/O methods are now part of data_io.py to avoid duplicating code and redefine methods like `read_cam_file`, `read_img`, reading of pair files, and reading/writing depth maps in pfm or COLMAP .bin format.